### PR TITLE
Add fixed admin access controls

### DIFF
--- a/shyne.py
+++ b/shyne.py
@@ -1,5 +1,7 @@
+import json
 import os
 from datetime import datetime, timedelta, timezone
+from functools import wraps
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -16,6 +18,10 @@ from flask import (
 )
 from flask_admin import Admin, AdminIndexView
 from flask_admin.contrib.sqla import ModelView
+try:
+    from flask_admin.theme import Bootstrap4Theme
+except ImportError:  # Flask-Admin < 2.0
+    Bootstrap4Theme = None
 from flask_login import (
     LoginManager,
     UserMixin,
@@ -27,16 +33,178 @@ from flask_login import (
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import validates
 from sqlalchemy import inspect, or_, text
+from sqlalchemy.exc import OperationalError
 from werkzeug.security import check_password_hash, generate_password_hash
 
 FAILED_LOGIN_THRESHOLD = 5
 ACCOUNT_LOCK_DURATION = timedelta(minutes=15)
+INVITE_EXPIRY_DURATION = timedelta(days=7)
 BASE_DIR = Path(__file__).resolve().parent
 AUTH_BIND_KEY = "auth"
 PASSWORD_HASH_METHOD = "pbkdf2:sha256:1000000"
 DEV_TEST_ADMIN_EMAIL = "admin"
 DEV_TEST_ADMIN_PASSWORD = "admin"
 DEV_TEST_ADMIN_FULL_NAME = "Dev Admin"
+ROLE_STAFF_OPERATOR = "Staff Operator"
+ROLE_INVENTORY_PRODUCTION = "Inventory / Production"
+ROLE_SUPERADMIN = "Superadmin"
+ROLE_DEV_ADMIN = "Dev Admin"
+BUSINESS_ROLE_CHOICES = (
+    ROLE_STAFF_OPERATOR,
+    ROLE_INVENTORY_PRODUCTION,
+    ROLE_SUPERADMIN,
+)
+ALL_ROLE_CHOICES = BUSINESS_ROLE_CHOICES + (ROLE_DEV_ADMIN,)
+ROLE_SLUG_MAP = {
+    "staff-operator": ROLE_STAFF_OPERATOR,
+    "inventory-production": ROLE_INVENTORY_PRODUCTION,
+    "superadmin": ROLE_SUPERADMIN,
+}
+ROLE_LABEL_TO_SLUG = {label: slug for slug, label in ROLE_SLUG_MAP.items()}
+ACCOUNT_STATUS_INVITED = "invited"
+ACCOUNT_STATUS_ACTIVE = "active"
+ACCOUNT_STATUS_SUSPENDED = "suspended"
+ACCOUNT_STATUS_CHOICES = (
+    ACCOUNT_STATUS_INVITED,
+    ACCOUNT_STATUS_ACTIVE,
+    ACCOUNT_STATUS_SUSPENDED,
+)
+PERMISSION_DASHBOARD_VIEW = "dashboard.view"
+PERMISSION_ORDERS_VIEW = "orders.view"
+PERMISSION_ORDERS_EDIT = "orders.edit"
+PERMISSION_CUSTOMERS_VIEW = "customers.view"
+PERMISSION_CUSTOMERS_EDIT = "customers.edit"
+PERMISSION_SHIPPING_VIEW = "shipping.view"
+PERMISSION_SHIPPING_EDIT = "shipping.edit"
+PERMISSION_INVENTORY_VIEW = "inventory.view"
+PERMISSION_INVENTORY_EDIT = "inventory.edit"
+PERMISSION_PRODUCTION_VIEW = "production.view"
+PERMISSION_PRODUCTION_EDIT = "production.edit"
+PERMISSION_TASKS_VIEW = "tasks.view"
+PERMISSION_TASKS_EDIT = "tasks.edit"
+PERMISSION_REPORTS_VIEW = "reports.view"
+PERMISSION_USERS_VIEW = "users.view"
+PERMISSION_USERS_MANAGE = "users.manage"
+PERMISSION_ADMIN_CONSOLE_ACCESS = "admin_console.access"
+ALL_PERMISSION_KEYS = (
+    PERMISSION_DASHBOARD_VIEW,
+    PERMISSION_ORDERS_VIEW,
+    PERMISSION_ORDERS_EDIT,
+    PERMISSION_CUSTOMERS_VIEW,
+    PERMISSION_CUSTOMERS_EDIT,
+    PERMISSION_SHIPPING_VIEW,
+    PERMISSION_SHIPPING_EDIT,
+    PERMISSION_INVENTORY_VIEW,
+    PERMISSION_INVENTORY_EDIT,
+    PERMISSION_PRODUCTION_VIEW,
+    PERMISSION_PRODUCTION_EDIT,
+    PERMISSION_TASKS_VIEW,
+    PERMISSION_TASKS_EDIT,
+    PERMISSION_REPORTS_VIEW,
+    PERMISSION_USERS_VIEW,
+    PERMISSION_USERS_MANAGE,
+    PERMISSION_ADMIN_CONSOLE_ACCESS,
+)
+PERMISSION_LABELS = {
+    PERMISSION_DASHBOARD_VIEW: "Dashboard",
+    PERMISSION_ORDERS_VIEW: "Orders",
+    PERMISSION_ORDERS_EDIT: "Orders",
+    PERMISSION_CUSTOMERS_VIEW: "Customers",
+    PERMISSION_CUSTOMERS_EDIT: "Customers",
+    PERMISSION_SHIPPING_VIEW: "Shipping",
+    PERMISSION_SHIPPING_EDIT: "Shipping",
+    PERMISSION_INVENTORY_VIEW: "Inventory",
+    PERMISSION_INVENTORY_EDIT: "Inventory",
+    PERMISSION_PRODUCTION_VIEW: "Production",
+    PERMISSION_PRODUCTION_EDIT: "Production",
+    PERMISSION_TASKS_VIEW: "Tasks",
+    PERMISSION_TASKS_EDIT: "Tasks",
+    PERMISSION_REPORTS_VIEW: "Reports",
+    PERMISSION_USERS_VIEW: "Users & Access",
+    PERMISSION_USERS_MANAGE: "Users & Access",
+    PERMISSION_ADMIN_CONSOLE_ACCESS: "Admin Console",
+}
+OVERRIDE_ALLOWLIST = frozenset(
+    permission
+    for permission in ALL_PERMISSION_KEYS
+    if permission != PERMISSION_ADMIN_CONSOLE_ACCESS
+)
+ROLE_PERMISSION_MAP = {
+    ROLE_STAFF_OPERATOR: frozenset(
+        {
+            PERMISSION_DASHBOARD_VIEW,
+            PERMISSION_ORDERS_VIEW,
+            PERMISSION_ORDERS_EDIT,
+            PERMISSION_CUSTOMERS_VIEW,
+            PERMISSION_CUSTOMERS_EDIT,
+            PERMISSION_SHIPPING_VIEW,
+            PERMISSION_SHIPPING_EDIT,
+            PERMISSION_INVENTORY_VIEW,
+            PERMISSION_PRODUCTION_VIEW,
+            PERMISSION_TASKS_VIEW,
+            PERMISSION_TASKS_EDIT,
+            PERMISSION_REPORTS_VIEW,
+        }
+    ),
+    ROLE_INVENTORY_PRODUCTION: frozenset(
+        {
+            PERMISSION_DASHBOARD_VIEW,
+            PERMISSION_ORDERS_VIEW,
+            PERMISSION_CUSTOMERS_VIEW,
+            PERMISSION_SHIPPING_VIEW,
+            PERMISSION_INVENTORY_VIEW,
+            PERMISSION_INVENTORY_EDIT,
+            PERMISSION_PRODUCTION_VIEW,
+            PERMISSION_PRODUCTION_EDIT,
+            PERMISSION_TASKS_VIEW,
+            PERMISSION_REPORTS_VIEW,
+        }
+    ),
+    ROLE_SUPERADMIN: frozenset(
+        {
+            PERMISSION_DASHBOARD_VIEW,
+            PERMISSION_ORDERS_VIEW,
+            PERMISSION_ORDERS_EDIT,
+            PERMISSION_CUSTOMERS_VIEW,
+            PERMISSION_CUSTOMERS_EDIT,
+            PERMISSION_SHIPPING_VIEW,
+            PERMISSION_SHIPPING_EDIT,
+            PERMISSION_INVENTORY_VIEW,
+            PERMISSION_INVENTORY_EDIT,
+            PERMISSION_PRODUCTION_VIEW,
+            PERMISSION_PRODUCTION_EDIT,
+            PERMISSION_TASKS_VIEW,
+            PERMISSION_TASKS_EDIT,
+            PERMISSION_REPORTS_VIEW,
+            PERMISSION_USERS_VIEW,
+            PERMISSION_USERS_MANAGE,
+        }
+    ),
+    ROLE_DEV_ADMIN: frozenset(
+        {
+            PERMISSION_DASHBOARD_VIEW,
+            PERMISSION_ORDERS_VIEW,
+            PERMISSION_CUSTOMERS_VIEW,
+            PERMISSION_SHIPPING_VIEW,
+            PERMISSION_INVENTORY_VIEW,
+            PERMISSION_PRODUCTION_VIEW,
+            PERMISSION_TASKS_VIEW,
+            PERMISSION_REPORTS_VIEW,
+            PERMISSION_ADMIN_CONSOLE_ACCESS,
+        }
+    ),
+}
+ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS = "success"
+ADMIN_ACCESS_EVENT_OUTCOME_DENIED = "denied"
+ADMIN_ACCESS_EVENT_OUTCOME_CANCELLED = "cancelled"
+ADMIN_ACCESS_EVENT_INVITE_CREATED = "invite.created"
+ADMIN_ACCESS_EVENT_INVITE_RESENT = "invite.resent"
+ADMIN_ACCESS_EVENT_INVITE_CANCELLED = "invite.cancelled"
+ADMIN_ACCESS_EVENT_ACCOUNT_ACTIVATED = "account.activated"
+ADMIN_ACCESS_EVENT_PASSWORD_RESET = "account.password_reset"
+ADMIN_ACCESS_EVENT_ROLE_CHANGED = "account.role_changed"
+ADMIN_ACCESS_EVENT_STATUS_CHANGED = "account.status_changed"
+ADMIN_ACCESS_EVENT_ACCESS_DENIED = "access.denied"
 CUSTOMER_SOURCE_OPTIONS = ("Fiverr", "Square", "Manual Entry")
 GOOGLE_SHEETS_ORDER_SOURCE = "Google Sheets"
 SECURITY_HEADERS = {
@@ -44,7 +212,16 @@ SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "SAMEORIGIN",
 }
-NO_STORE_ENDPOINTS = {"index", "login", "logout", "orders", "tasks", "customers"}
+NO_STORE_ENDPOINTS = {
+    "index",
+    "login",
+    "logout",
+    "orders",
+    "tasks",
+    "customers",
+    "inventory",
+    "users",
+}
 
 
 def require_env(name):
@@ -149,6 +326,35 @@ def current_request_next_target():
     return request.path
 
 
+def slug_to_role_label(value):
+    if value not in ROLE_SLUG_MAP:
+        raise click.ClickException(
+            "Role must be one of: "
+            + ", ".join(sorted(ROLE_SLUG_MAP))
+            + "."
+        )
+    return ROLE_SLUG_MAP[value]
+
+
+def serialize_state(value):
+    if value is None:
+        return None
+    return json.dumps(value, sort_keys=True)
+
+
+def deserialize_state(value, default=None):
+    if not value:
+        return [] if default is None else default
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return [] if default is None else default
+
+
+def unique_strings(values):
+    return sorted({value for value in values if value})
+
+
 def dev_test_admin_enabled(flask_app=None):
     target_app = flask_app or app
     return bool(target_app.config.get("ENABLE_DEV_TEST_ADMIN")) and (
@@ -205,15 +411,87 @@ def ensure_customer_source_column():
         )
 
 
+def ensure_admin_user_access_columns():
+    auth_engine = db.engines[AUTH_BIND_KEY]
+    inspector = inspect(auth_engine)
+    if "admin_users" not in inspector.get_table_names():
+        return
+
+    def read_admin_user_columns():
+        return {
+            column["name"] for column in inspect(auth_engine).get_columns("admin_users")
+        }
+
+    admin_user_columns = read_admin_user_columns()
+    missing_columns = {
+        "role": "ALTER TABLE admin_users ADD COLUMN role VARCHAR(64)",
+        "account_status": "ALTER TABLE admin_users ADD COLUMN account_status VARCHAR(32)",
+        "invited_at": "ALTER TABLE admin_users ADD COLUMN invited_at DATETIME",
+        "invited_by_user_id": "ALTER TABLE admin_users ADD COLUMN invited_by_user_id INTEGER",
+        "activated_at": "ALTER TABLE admin_users ADD COLUMN activated_at DATETIME",
+        "suspended_at": "ALTER TABLE admin_users ADD COLUMN suspended_at DATETIME",
+        "suspended_by_user_id": "ALTER TABLE admin_users ADD COLUMN suspended_by_user_id INTEGER",
+        "access_granted_by_user_id": "ALTER TABLE admin_users ADD COLUMN access_granted_by_user_id INTEGER",
+        "last_role_changed_at": "ALTER TABLE admin_users ADD COLUMN last_role_changed_at DATETIME",
+        "last_role_changed_by_user_id": "ALTER TABLE admin_users ADD COLUMN last_role_changed_by_user_id INTEGER",
+        "permission_overrides_json": "ALTER TABLE admin_users ADD COLUMN permission_overrides_json TEXT",
+    }
+
+    with auth_engine.begin() as connection:
+        for column_name, statement in missing_columns.items():
+            if column_name not in admin_user_columns:
+                try:
+                    connection.execute(text(statement))
+                except OperationalError as exc:
+                    if "duplicate column name" not in str(exc).lower():
+                        raise
+                admin_user_columns = read_admin_user_columns()
+
+        if "role" in admin_user_columns:
+            connection.execute(
+                text("CREATE INDEX IF NOT EXISTS idx_admin_users_role ON admin_users (role)")
+            )
+        if "account_status" in admin_user_columns:
+            connection.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS idx_admin_users_account_status "
+                    "ON admin_users (account_status)"
+                )
+            )
+
+
+def ensure_runtime_auth_schema_compatibility():
+    auth_engine = db.engines[AUTH_BIND_KEY]
+    inspector = inspect(auth_engine)
+    if "admin_users" not in inspector.get_table_names():
+        return
+
+    # Keep older auth databases readable by adding the shipped access columns
+    # and audit table before request-time queries hit the ORM.
+    AdminAccessEvent.__table__.create(bind=auth_engine, checkfirst=True)
+    ensure_admin_user_access_columns()
+
+
 class AdminUser(UserMixin, db.Model):
     __bind_key__ = AUTH_BIND_KEY
     __tablename__ = "admin_users"
 
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(255), unique=True, nullable=False, index=True)
-    password_hash = db.Column(db.String(255), nullable=False)
+    password_hash = db.Column(db.String(255))
     full_name = db.Column(db.String(255))
     is_active = db.Column(db.Boolean, nullable=False, default=True)
+    role = db.Column(db.String(64), index=True)
+    account_status = db.Column(db.String(32), index=True)
+    invited_at = db.Column(db.DateTime(timezone=True))
+    invited_by_user_id = db.Column(db.Integer)
+    activated_at = db.Column(db.DateTime(timezone=True))
+    suspended_at = db.Column(db.DateTime(timezone=True))
+    suspended_by_user_id = db.Column(db.Integer)
+    access_granted_by_user_id = db.Column(db.Integer)
+    last_role_changed_at = db.Column(db.DateTime(timezone=True))
+    last_role_changed_by_user_id = db.Column(db.Integer)
+    permission_overrides_json = db.Column(db.Text)
     failed_login_count = db.Column(db.Integer, nullable=False, default=0)
     locked_until = db.Column(db.DateTime(timezone=True))
     last_login_at = db.Column(db.DateTime(timezone=True))
@@ -228,6 +506,22 @@ class AdminUser(UserMixin, db.Model):
             raise ValueError("Email is required.")
         return normalized
 
+    @validates("role")
+    def validate_role(self, _key, value):
+        if value in {None, ""}:
+            return None
+        if value not in ALL_ROLE_CHOICES:
+            raise ValueError("Role must use one of the fixed v1 role labels.")
+        return value
+
+    @validates("account_status")
+    def validate_account_status(self, _key, value):
+        if value in {None, ""}:
+            return None
+        if value not in ACCOUNT_STATUS_CHOICES:
+            raise ValueError("Account status must be invited, active, or suspended.")
+        return value
+
     def set_password(self, password):
         if not password:
             raise ValueError("Password is required.")
@@ -240,11 +534,74 @@ class AdminUser(UserMixin, db.Model):
             return False
         return check_password_hash(self.password_hash, password)
 
+    def get_role(self):
+        return self.role or ROLE_STAFF_OPERATOR
+
+    def get_account_status(self):
+        if self.account_status in ACCOUNT_STATUS_CHOICES:
+            return self.account_status
+        return ACCOUNT_STATUS_ACTIVE if self.is_active else ACCOUNT_STATUS_SUSPENDED
+
+    def sync_legacy_state(self):
+        self.is_active = self.get_account_status() == ACCOUNT_STATUS_ACTIVE
+        if self.role is None:
+            self.role = self.get_role()
+
+    def set_account_status(self, status, *, actor=None, now=None):
+        comparison_time = now or utc_now()
+        self.account_status = status
+        self.is_active = status == ACCOUNT_STATUS_ACTIVE
+        if status == ACCOUNT_STATUS_ACTIVE:
+            self.suspended_at = None
+            self.suspended_by_user_id = None
+            if self.activated_at is None:
+                self.activated_at = comparison_time
+            if actor is not None:
+                self.access_granted_by_user_id = actor.id
+        elif status == ACCOUNT_STATUS_INVITED:
+            self.invited_at = comparison_time
+            self.activated_at = None
+            self.suspended_at = None
+            self.suspended_by_user_id = None
+            self.access_granted_by_user_id = None if actor is None else actor.id
+        elif status == ACCOUNT_STATUS_SUSPENDED:
+            self.suspended_at = comparison_time
+            self.suspended_by_user_id = None if actor is None else actor.id
+
+    def set_role(self, role, *, actor=None, now=None):
+        comparison_time = now or utc_now()
+        self.role = role
+        self.last_role_changed_at = comparison_time
+        self.last_role_changed_by_user_id = None if actor is None else actor.id
+
+    def set_permission_overrides(self, permission_keys):
+        permission_keys = unique_strings(permission_keys)
+        unknown_keys = set(permission_keys) - OVERRIDE_ALLOWLIST
+        if unknown_keys:
+            raise ValueError(
+                "Permission overrides must use the allowlisted bundle keys only."
+            )
+        self.permission_overrides_json = serialize_state(permission_keys)
+
+    def get_permission_overrides(self):
+        overrides = deserialize_state(self.permission_overrides_json, default=[])
+        if not isinstance(overrides, list):
+            return []
+        return unique_strings(
+            value for value in overrides if isinstance(value, str) and value in OVERRIDE_ALLOWLIST
+        )
+
     def is_locked(self, now=None):
         if self.locked_until is None:
             return False
         comparison_time = now or utc_now()
         return ensure_utc(self.locked_until) > comparison_time
+
+    def is_invite_expired(self, now=None):
+        if self.get_account_status() != ACCOUNT_STATUS_INVITED or self.invited_at is None:
+            return False
+        comparison_time = now or utc_now()
+        return ensure_utc(self.invited_at) + INVITE_EXPIRY_DURATION <= comparison_time
 
     def register_failed_login(self, now=None):
         comparison_time = now or utc_now()
@@ -260,6 +617,40 @@ class AdminUser(UserMixin, db.Model):
     def reset_login_state(self):
         self.failed_login_count = 0
         self.locked_until = None
+
+    def display_status(self, now=None):
+        if self.is_locked(now):
+            return "Locked"
+        if self.is_invite_expired(now):
+            return "Expired invite"
+        status = self.get_account_status()
+        if status == ACCOUNT_STATUS_INVITED:
+            return "Pending invite"
+        if status == ACCOUNT_STATUS_ACTIVE:
+            return "Active"
+        if status == ACCOUNT_STATUS_SUSPENDED:
+            return "Suspended"
+        return "Unknown"
+
+    def role_slug(self):
+        return ROLE_LABEL_TO_SLUG.get(self.get_role(), "")
+
+
+class AdminAccessEvent(db.Model):
+    __bind_key__ = AUTH_BIND_KEY
+    __tablename__ = "admin_access_events"
+
+    id = db.Column(db.Integer, primary_key=True)
+    actor_user_id = db.Column(db.Integer, index=True)
+    target_user_id = db.Column(db.Integer, index=True)
+    event_type = db.Column(db.String(80), nullable=False, index=True)
+    outcome = db.Column(db.String(32), nullable=False, index=True)
+    before_state_json = db.Column(db.Text)
+    after_state_json = db.Column(db.Text)
+    note = db.Column(db.Text)
+    created_at = db.Column(
+        db.DateTime(timezone=True), default=utc_now, nullable=False, index=True
+    )
 
 
 class Customer(db.Model):
@@ -473,12 +864,263 @@ class Shipment(db.Model):
     order = db.relationship("Order", back_populates="shipment")
 
 
+def summarize_permissions(permission_keys):
+    labels = []
+    for permission_key in permission_keys:
+        label = PERMISSION_LABELS.get(permission_key)
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def serialize_admin_user_snapshot(admin_user, *, now=None):
+    comparison_time = now or utc_now()
+    return {
+        "email": admin_user.email,
+        "full_name": admin_user.full_name,
+        "role": admin_user.get_role(),
+        "account_status": admin_user.get_account_status(),
+        "display_status": admin_user.display_status(comparison_time),
+        "is_active": bool(admin_user.is_active),
+        "is_locked": admin_user.is_locked(comparison_time),
+        "permission_overrides": admin_user.get_permission_overrides(),
+    }
+
+
+def log_admin_access_event(
+    *,
+    actor=None,
+    target=None,
+    event_type,
+    outcome,
+    before_state=None,
+    after_state=None,
+    note=None,
+):
+    db.session.add(
+        AdminAccessEvent(
+            actor_user_id=None if actor is None else actor.id,
+            target_user_id=None if target is None else target.id,
+            event_type=event_type,
+            outcome=outcome,
+            before_state_json=serialize_state(before_state),
+            after_state_json=serialize_state(after_state),
+            note=note,
+        )
+    )
+
+
+def get_effective_permissions(admin_user):
+    if admin_user is None:
+        return frozenset()
+    role_permissions = ROLE_PERMISSION_MAP.get(admin_user.get_role(), frozenset())
+    override_permissions = frozenset(admin_user.get_permission_overrides())
+    return frozenset(role_permissions.union(override_permissions))
+
+
+def has_permission(permission_key, admin_user=None, *, now=None):
+    target_user = admin_user or current_user
+    if not getattr(target_user, "is_authenticated", False):
+        return False
+    if target_user.get_account_status() != ACCOUNT_STATUS_ACTIVE:
+        return False
+    if target_user.is_locked(now):
+        return False
+    return permission_key in get_effective_permissions(target_user)
+
+
+def is_superadmin(admin_user=None):
+    target_user = admin_user or current_user
+    return getattr(target_user, "is_authenticated", False) and (
+        target_user.get_role() == ROLE_SUPERADMIN
+    )
+
+
+def is_dev_admin(admin_user=None):
+    target_user = admin_user or current_user
+    return getattr(target_user, "is_authenticated", False) and (
+        target_user.get_role() == ROLE_DEV_ADMIN
+    )
+
+
+def is_last_active_superadmin(admin_user, *, now=None):
+    if admin_user is None or admin_user.get_role() != ROLE_SUPERADMIN:
+        return False
+    comparison_time = now or utc_now()
+    active_superadmins = (
+        AdminUser.query.filter(
+            AdminUser.role == ROLE_SUPERADMIN,
+            AdminUser.account_status == ACCOUNT_STATUS_ACTIVE,
+        )
+        .all()
+    )
+    return len(
+        [user for user in active_superadmins if not user.is_locked(comparison_time)]
+    ) <= 1
+
+
+def role_scope_summary(role_label):
+    return {
+        ROLE_STAFF_OPERATOR: "Orders, customers, shipping, tasks",
+        ROLE_INVENTORY_PRODUCTION: "Inventory, production, stock",
+        ROLE_SUPERADMIN: "Business admin and users",
+        ROLE_DEV_ADMIN: "Technical console access",
+    }.get(role_label, "Operational access")
+
+
+def resolve_actor_name(user_id):
+    if not user_id:
+        return "System"
+    admin_user = db.session.get(AdminUser, user_id)
+    if admin_user is None:
+        return "Unknown user"
+    return admin_user.full_name or admin_user.email
+
+
+def parse_last_login_state(admin_user, *, now=None):
+    comparison_time = now or utc_now()
+    if admin_user.is_locked(comparison_time):
+        return "locked"
+    if admin_user.last_login_at is None:
+        return "never"
+    if ensure_utc(admin_user.last_login_at) >= comparison_time - timedelta(days=14):
+        return "recent"
+    return "stale"
+
+
+def visible_users_query():
+    return AdminUser.query.filter(
+        or_(AdminUser.role.is_(None), AdminUser.role != ROLE_DEV_ADMIN)
+    )
+
+
+def users_redirect_response(
+    *,
+    selected_user_id=None,
+    show_invite=False,
+    search="",
+    role_filter="",
+    status_filter="",
+    last_login_filter="",
+):
+    query_params = {}
+    if search:
+        query_params["search"] = search
+    if role_filter:
+        query_params["role_filter"] = role_filter
+    if status_filter:
+        query_params["status_filter"] = status_filter
+    if last_login_filter:
+        query_params["last_login_filter"] = last_login_filter
+    if selected_user_id is not None:
+        query_params["selected_user"] = selected_user_id
+    if show_invite:
+        query_params["show_invite"] = "1"
+    return redirect(url_for("users", **query_params))
+
+
+def read_users_filter_state(source=None):
+    source = source or request.values
+    return {
+        "search": (source.get("search") or "").strip(),
+        "role_filter": (source.get("role_filter") or "").strip(),
+        "status_filter": (source.get("status_filter") or "").strip(),
+        "last_login_filter": (source.get("last_login_filter") or "").strip(),
+    }
+
+
+def get_visible_user_or_none(user_id):
+    if not user_id:
+        return None
+    return visible_users_query().filter(AdminUser.id == user_id).first()
+
+
+def deny_sensitive_users_action(target_user, *, note):
+    flash(note, "error")
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_ACCESS_DENIED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_DENIED,
+        note=note,
+    )
+    db.session.commit()
+
+
+def sort_visible_users(users, *, now=None):
+    comparison_time = now or utc_now()
+    status_priority = {
+        "Active": 0,
+        "Locked": 1,
+        "Pending invite": 2,
+        "Expired invite": 3,
+        "Suspended": 4,
+    }
+    return sorted(
+        users,
+        key=lambda user: (
+            status_priority.get(user.display_status(comparison_time), 99),
+            (user.full_name or "").lower(),
+            user.email.lower(),
+        ),
+    )
+
+
+def require_permission(permission_key, *, denial_title="Access denied", denial_message=None):
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapped(*args, **kwargs):
+            if not current_user.is_authenticated:
+                return login_manager.unauthorized()
+            if has_permission(permission_key):
+                return view_func(*args, **kwargs)
+
+            log_admin_access_event(
+                actor=current_user,
+                target=current_user,
+                event_type=ADMIN_ACCESS_EVENT_ACCESS_DENIED,
+                outcome=ADMIN_ACCESS_EVENT_OUTCOME_DENIED,
+                note=f"{request.method} {request.path}",
+            )
+            db.session.commit()
+            return (
+                render_template(
+                    "access_denied.html",
+                    page_title=denial_title,
+                    denial_message=denial_message
+                    or "You do not have permission to access this page.",
+                ),
+                403,
+            )
+
+        return wrapped
+
+    return decorator
+
+
 class SecureAdminIndexView(AdminIndexView):
     def is_accessible(self):
-        return current_user.is_authenticated and current_user.is_active
+        return has_permission(PERMISSION_ADMIN_CONSOLE_ACCESS)
 
     def inaccessible_callback(self, name, **kwargs):
-        return redirect(url_for("login", next=current_request_next_target()))
+        if not current_user.is_authenticated:
+            return redirect(url_for("login", next=current_request_next_target()))
+        log_admin_access_event(
+            actor=current_user,
+            target=current_user,
+            event_type=ADMIN_ACCESS_EVENT_ACCESS_DENIED,
+            outcome=ADMIN_ACCESS_EVENT_OUTCOME_DENIED,
+            note=f"GET {request.path}",
+        )
+        db.session.commit()
+        return (
+            render_template(
+                "access_denied.html",
+                page_title="Admin console access denied",
+                denial_message="Dev Admin access is required to use the technical admin console.",
+            ),
+            403,
+        )
 
 
 class LiveDataModelView(ModelView):
@@ -489,10 +1131,27 @@ class LiveDataModelView(ModelView):
     column_display_pk = True
 
     def is_accessible(self):
-        return current_user.is_authenticated and current_user.is_active
+        return has_permission(PERMISSION_ADMIN_CONSOLE_ACCESS)
 
     def inaccessible_callback(self, name, **kwargs):
-        return redirect(url_for("login", next=current_request_next_target()))
+        if not current_user.is_authenticated:
+            return redirect(url_for("login", next=current_request_next_target()))
+        log_admin_access_event(
+            actor=current_user,
+            target=current_user,
+            event_type=ADMIN_ACCESS_EVENT_ACCESS_DENIED,
+            outcome=ADMIN_ACCESS_EVENT_OUTCOME_DENIED,
+            note=f"GET {request.path}",
+        )
+        db.session.commit()
+        return (
+            render_template(
+                "access_denied.html",
+                page_title="Admin console access denied",
+                denial_message="Dev Admin access is required to use the technical admin console.",
+            ),
+            403,
+        )
 
 
 # Model map used to register all SQLAlchemy tables in Flask-Admin.
@@ -513,8 +1172,8 @@ MODEL_REGISTRY = {
 admin = Admin(
     app,
     name="ShyneBeauty Admin",
-    template_mode="bootstrap4",
     index_view=SecureAdminIndexView(url="/admin/"),
+    **({"theme": Bootstrap4Theme()} if Bootstrap4Theme is not None else {}),
 )
 _admin_views_registered = False
 
@@ -546,6 +1205,14 @@ def handle_unauthorized():
     return redirect(url_for("login", next=current_request_next_target()))
 
 
+@app.before_request
+def ensure_request_auth_schema_compatibility():
+    if request.endpoint == "static":
+        return None
+    ensure_runtime_auth_schema_compatibility()
+    return None
+
+
 @app.after_request
 def add_security_headers(response):
     for header_name, header_value in SECURITY_HEADERS.items():
@@ -564,13 +1231,52 @@ def add_security_headers(response):
 @app.context_processor
 def inject_current_admin_label():
     label = None
+    role_label = None
+    nav_items = []
     if current_user.is_authenticated:
         label = current_user.full_name or current_user.email
-    return {"current_admin_label": label}
+        role_label = current_user.get_role()
+        nav_items = [
+            {
+                "endpoint": "index",
+                "label": "Home Dashboard",
+                "visible": has_permission(PERMISSION_DASHBOARD_VIEW),
+            },
+            {
+                "endpoint": "orders",
+                "label": "Manage Orders",
+                "visible": has_permission(PERMISSION_ORDERS_VIEW),
+            },
+            {
+                "endpoint": "inventory",
+                "label": "Inventory",
+                "visible": has_permission(PERMISSION_INVENTORY_VIEW),
+            },
+            {
+                "endpoint": "customers",
+                "label": "Customers",
+                "visible": has_permission(PERMISSION_CUSTOMERS_VIEW),
+            },
+            {
+                "endpoint": "tasks",
+                "label": "Tasks",
+                "visible": has_permission(PERMISSION_TASKS_VIEW),
+            },
+            {
+                "endpoint": "users",
+                "label": "Users & Access",
+                "visible": has_permission(PERMISSION_USERS_MANAGE),
+            },
+        ]
+    return {
+        "current_admin_label": label,
+        "current_admin_role_label": role_label,
+        "authenticated_nav_items": [item for item in nav_items if item["visible"]],
+    }
 
 
 @app.route("/")
-@login_required
+@require_permission(PERMISSION_DASHBOARD_VIEW)
 def index():
     total_orders = db.session.query(Order).count()
     ready_to_ship_count = db.session.query(Order).filter(Order.status == "Ready").count()
@@ -625,9 +1331,14 @@ def login():
                 flash("Invalid email or password.", "error")
             elif admin_user and admin_user.is_locked(now):
                 flash("Invalid email or password.", "error")
-            elif admin_user and admin_user.is_active and admin_user.check_password(password):
+            elif (
+                admin_user
+                and admin_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+                and admin_user.check_password(password)
+            ):
                 admin_user.reset_login_state()
                 admin_user.last_login_at = now
+                admin_user.sync_legacy_state()
                 db.session.commit()
 
                 session.clear()
@@ -663,7 +1374,7 @@ def login():
 
 
 @app.route("/orders")
-@login_required
+@require_permission(PERMISSION_ORDERS_VIEW)
 def orders():
     search_query = request.args.get("search", "").strip()
     source = request.args.get("source", "")
@@ -702,13 +1413,13 @@ def orders():
 
 
 @app.route("/tasks")
-@login_required
+@require_permission(PERMISSION_TASKS_VIEW)
 def tasks():
     return render_template("tasks.html")
 
 
 @app.route("/customers")
-@login_required
+@require_permission(PERMISSION_CUSTOMERS_VIEW)
 def customers():
     search_query = request.args.get("search", "").strip()
     source = request.args.get("source", "")
@@ -734,7 +1445,7 @@ def customers():
     )
 
 @app.route("/inventory")
-@login_required
+@require_permission(PERMISSION_INVENTORY_VIEW)
 def inventory():
     search_query = request.args.get('search', '').strip()
     category = request.args.get('category', '')
@@ -769,6 +1480,384 @@ def inventory():
                          selected_category=category,
                          selected_stock_status=stock_status)
 
+@app.route("/users")
+@require_permission(
+    PERMISSION_USERS_MANAGE,
+    denial_title="Users & Access denied",
+    denial_message="Superadmin access is required to manage internal staff accounts.",
+)
+def users():
+    filter_state = read_users_filter_state(request.args)
+    selected_user_id = request.args.get("selected_user", type=int)
+    show_invite = request.args.get("show_invite") == "1"
+    comparison_time = utc_now()
+    users_list = visible_users_query().order_by(AdminUser.created_at.desc()).all()
+    filtered_users = []
+
+    for admin_user in users_list:
+        full_name = (admin_user.full_name or "").strip()
+        if filter_state["search"]:
+            search_value = filter_state["search"].lower()
+            if search_value not in full_name.lower() and search_value not in admin_user.email.lower():
+                continue
+        if filter_state["role_filter"] and admin_user.get_role() != filter_state["role_filter"]:
+            continue
+
+        derived_status = admin_user.display_status(comparison_time)
+        status_matches = {
+            "active": derived_status == "Active",
+            "invited": derived_status == "Pending invite",
+            "expired": derived_status == "Expired invite",
+            "suspended": derived_status == "Suspended",
+            "locked": derived_status == "Locked",
+        }
+        if filter_state["status_filter"] and not status_matches.get(
+            filter_state["status_filter"],
+            False,
+        ):
+            continue
+        if filter_state["last_login_filter"] and parse_last_login_state(
+            admin_user, now=comparison_time
+        ) != filter_state["last_login_filter"]:
+            continue
+        filtered_users.append(admin_user)
+
+    filtered_users = sort_visible_users(filtered_users, now=comparison_time)
+    filtered_ids = {admin_user.id for admin_user in filtered_users}
+    selected_user = None if show_invite else get_visible_user_or_none(selected_user_id)
+    if selected_user and selected_user.id not in filtered_ids:
+        selected_user = None
+    if selected_user is None and filtered_users and not show_invite:
+        selected_user = filtered_users[0]
+
+    selected_user_events = []
+    if selected_user is not None:
+        selected_user_events = (
+            AdminAccessEvent.query.filter_by(target_user_id=selected_user.id)
+            .order_by(AdminAccessEvent.created_at.desc())
+            .limit(5)
+            .all()
+        )
+
+    return render_template(
+        "users.html",
+        users_list=filtered_users,
+        selected_user=selected_user,
+        selected_user_events=selected_user_events,
+        filter_state=filter_state,
+        show_invite=show_invite,
+        role_options=BUSINESS_ROLE_CHOICES,
+        status_options=(
+            ("active", "Active"),
+            ("invited", "Pending invite"),
+            ("expired", "Expired invite"),
+            ("suspended", "Suspended"),
+            ("locked", "Locked"),
+        ),
+        last_login_options=(
+            ("never", "Never logged in"),
+            ("recent", "Recent"),
+            ("stale", "Stale"),
+            ("locked", "Locked"),
+        ),
+        comparison_time=comparison_time,
+        permission_labels=summarize_permissions,
+        role_scope_summary=role_scope_summary,
+        parse_last_login_state=parse_last_login_state,
+        resolve_actor_name=resolve_actor_name,
+        get_effective_permissions=get_effective_permissions,
+    )
+
+
+@app.route("/users/invite", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def invite_user():
+    filter_state = read_users_filter_state(request.form)
+    email = normalize_email(request.form.get("email"))
+    full_name = (request.form.get("full_name") or "").strip()
+    role = request.form.get("role")
+    if not email:
+        flash("Email is required.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if role not in BUSINESS_ROLE_CHOICES:
+        flash("Select one of the fixed business roles.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    existing_user = AdminUser.query.filter_by(email=email).first()
+    if existing_user is not None:
+        flash("An account with that email already exists.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+
+    comparison_time = utc_now()
+    created_user = AdminUser(
+        email=email,
+        full_name=full_name or None,
+    )
+    created_user.set_role(role, actor=current_user, now=comparison_time)
+    created_user.set_account_status(
+        ACCOUNT_STATUS_INVITED, actor=current_user, now=comparison_time
+    )
+    created_user.invited_at = comparison_time
+    created_user.invited_by_user_id = current_user.id
+    created_user.reset_login_state()
+    db.session.add(created_user)
+    db.session.flush()
+    log_admin_access_event(
+        actor=current_user,
+        target=created_user,
+        event_type=ADMIN_ACCESS_EVENT_INVITE_CREATED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        after_state=serialize_admin_user_snapshot(created_user, now=comparison_time),
+    )
+    db.session.commit()
+    flash("Invite created successfully.", "success")
+    return users_redirect_response(
+        selected_user_id=created_user.id,
+        show_invite=False,
+        **filter_state,
+    )
+
+
+@app.route("/users/<int:user_id>/activate", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def activate_user(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    password = request.form.get("password") or ""
+    password_confirmation = request.form.get("password_confirmation") or ""
+    if not password:
+        flash("Initial password is required.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+    if password != password_confirmation:
+        flash("Passwords must match.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+    if target_user.get_account_status() != ACCOUNT_STATUS_INVITED:
+        flash("Only pending invites can be activated.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    comparison_time = utc_now()
+    before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
+    target_user.set_password(password)
+    target_user.set_account_status(
+        ACCOUNT_STATUS_ACTIVE, actor=current_user, now=comparison_time
+    )
+    target_user.reset_login_state()
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_ACCOUNT_ACTIVATED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        before_state=before_state,
+        after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
+    )
+    db.session.commit()
+    flash("Account activated.", "success")
+    return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+
+@app.route("/users/<int:user_id>/resend-invite", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def resend_invite(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if target_user.get_account_status() != ACCOUNT_STATUS_INVITED:
+        flash("Only pending invites can be resent.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    comparison_time = utc_now()
+    before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
+    target_user.invited_at = comparison_time
+    target_user.invited_by_user_id = current_user.id
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_INVITE_RESENT,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        before_state=before_state,
+        after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
+    )
+    db.session.commit()
+    flash("Invite resent.", "success")
+    return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+
+@app.route("/users/<int:user_id>/cancel-invite", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def cancel_invite(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if target_user.get_account_status() != ACCOUNT_STATUS_INVITED:
+        flash("Only pending invites can be cancelled.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    before_state = serialize_admin_user_snapshot(target_user)
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_INVITE_CANCELLED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_CANCELLED,
+        before_state=before_state,
+        note="Pending invite removed.",
+    )
+    db.session.delete(target_user)
+    db.session.commit()
+    flash("Invite cancelled.", "success")
+    return users_redirect_response(show_invite=True, **filter_state)
+
+
+@app.route("/users/<int:user_id>/role", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def update_user_role(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    new_role = request.form.get("role")
+    if new_role not in BUSINESS_ROLE_CHOICES:
+        flash("Select one of the fixed business roles.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+    if target_user.get_role() == ROLE_SUPERADMIN and new_role != ROLE_SUPERADMIN:
+        if is_last_active_superadmin(target_user):
+            deny_sensitive_users_action(
+                target_user,
+                note="You cannot demote the last active superadmin.",
+            )
+            return users_redirect_response(selected_user_id=user_id, **filter_state)
+    if target_user.get_role() == new_role:
+        flash("Role is already assigned.", "info")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    comparison_time = utc_now()
+    before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
+    target_user.set_role(new_role, actor=current_user, now=comparison_time)
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_ROLE_CHANGED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        before_state=before_state,
+        after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
+    )
+    db.session.commit()
+    flash("Role updated.", "success")
+    return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+
+@app.route("/users/<int:user_id>/suspend", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def suspend_user(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if target_user.get_account_status() == ACCOUNT_STATUS_SUSPENDED:
+        flash("Account is already suspended.", "info")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+    if target_user.get_role() == ROLE_SUPERADMIN and is_last_active_superadmin(target_user):
+        deny_sensitive_users_action(
+            target_user,
+            note="You cannot suspend the last active superadmin.",
+        )
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    comparison_time = utc_now()
+    before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
+    target_user.set_account_status(
+        ACCOUNT_STATUS_SUSPENDED, actor=current_user, now=comparison_time
+    )
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_STATUS_CHANGED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        before_state=before_state,
+        after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
+        note="Account suspended.",
+    )
+    db.session.commit()
+    flash("Account suspended.", "success")
+    return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+
+@app.route("/users/<int:user_id>/reactivate", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def reactivate_user(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if target_user.get_account_status() == ACCOUNT_STATUS_ACTIVE:
+        flash("Account is already active.", "info")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    comparison_time = utc_now()
+    before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
+    target_user.set_account_status(
+        ACCOUNT_STATUS_ACTIVE, actor=current_user, now=comparison_time
+    )
+    target_user.reset_login_state()
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_STATUS_CHANGED,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        before_state=before_state,
+        after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
+        note="Account reactivated.",
+    )
+    db.session.commit()
+    flash("Account reactivated.", "success")
+    return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+
+@app.route("/users/<int:user_id>/temporary-password", methods=["POST"])
+@require_permission(PERMISSION_USERS_MANAGE)
+def set_temporary_password(user_id):
+    filter_state = read_users_filter_state(request.form)
+    target_user = get_visible_user_or_none(user_id)
+    if target_user is None:
+        flash("User not found.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if target_user.get_account_status() != ACCOUNT_STATUS_ACTIVE:
+        flash("Only active accounts can receive a temporary password.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+    password = request.form.get("password") or ""
+    password_confirmation = request.form.get("password_confirmation") or ""
+    if not password:
+        flash("Temporary password is required.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+    if password != password_confirmation:
+        flash("Passwords must match.", "error")
+        return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+    comparison_time = utc_now()
+    before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
+    target_user.set_password(password)
+    target_user.reset_login_state()
+    log_admin_access_event(
+        actor=current_user,
+        target=target_user,
+        event_type=ADMIN_ACCESS_EVENT_PASSWORD_RESET,
+        outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+        before_state=before_state,
+        after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
+    )
+    db.session.commit()
+    flash("Password reset successfully.", "success")
+    return users_redirect_response(selected_user_id=user_id, **filter_state)
+
+
 @app.route("/logout", methods=["POST"])
 @login_required
 def logout():
@@ -781,18 +1870,36 @@ def logout():
 def init_db_command():
     db.create_all(bind_key="__all__")
     ensure_customer_source_column()
+    ensure_admin_user_access_columns()
     print("Database initialized.")
+
+
+def choose_default_business_role():
+    has_business_admin = (
+        AdminUser.query.filter(
+            AdminUser.role == ROLE_SUPERADMIN,
+            AdminUser.account_status == ACCOUNT_STATUS_ACTIVE,
+        ).first()
+        is not None
+    )
+    return ROLE_STAFF_OPERATOR if has_business_admin else ROLE_SUPERADMIN
 
 
 @app.cli.command("create-admin")
 @click.option("--email", required=True, help="Admin email address.")
 @click.option("--full-name", default=None, help="Optional admin display name.")
 @click.option(
+    "--role",
+    type=click.Choice(sorted(ROLE_SLUG_MAP)),
+    default=None,
+    help="Fixed business role for the account.",
+)
+@click.option(
     "--update",
     is_flag=True,
     help="Update an existing admin user instead of failing if the email already exists.",
 )
-def create_admin_command(email, full_name, update):
+def create_admin_command(email, full_name, role, update):
     normalized_email = normalize_email(email)
     if not normalized_email:
         raise click.ClickException("A valid email address is required.")
@@ -805,8 +1912,10 @@ def create_admin_command(email, full_name, update):
     if not password:
         raise click.ClickException("Password cannot be empty.")
 
-    db.create_all(bind_key=[AUTH_BIND_KEY])
+    db.create_all(bind_key=AUTH_BIND_KEY)
+    ensure_admin_user_access_columns()
     admin_user = AdminUser.query.filter_by(email=normalized_email).first()
+    role_label = None if role is None else slug_to_role_label(role)
 
     if admin_user and not update:
         raise click.ClickException(
@@ -823,19 +1932,124 @@ def create_admin_command(email, full_name, update):
     if full_name is not None:
         admin_user.full_name = full_name.strip() or None
 
-    admin_user.is_active = True
+    comparison_time = utc_now()
+    if role_label is None:
+        role_label = admin_user.role or choose_default_business_role()
+    admin_user.set_role(role_label, now=comparison_time)
+    admin_user.set_account_status(
+        ACCOUNT_STATUS_ACTIVE, actor=None, now=comparison_time
+    )
     admin_user.reset_login_state()
     admin_user.set_password(password)
+    admin_user.sync_legacy_state()
     db.session.commit()
 
-    click.echo(f"Admin user {action}: {normalized_email}")
+    click.echo(f"Admin user {action}: {normalized_email} ({admin_user.get_role()})")
+
+
+@app.cli.command("create-dev-admin")
+@click.option("--email", required=True, help="Dev Admin email address.")
+@click.option("--full-name", default=DEV_TEST_ADMIN_FULL_NAME, help="Optional display name.")
+@click.option(
+    "--update",
+    is_flag=True,
+    help="Update an existing Dev Admin instead of failing if the email already exists.",
+)
+def create_dev_admin_command(email, full_name, update):
+    normalized_email = normalize_email(email)
+    if not normalized_email:
+        raise click.ClickException("A valid email address is required.")
+    password = click.prompt("Password", hide_input=True, confirmation_prompt=True)
+    if not password:
+        raise click.ClickException("Password cannot be empty.")
+
+    db.create_all(bind_key=AUTH_BIND_KEY)
+    ensure_admin_user_access_columns()
+    admin_user = AdminUser.query.filter_by(email=normalized_email).first()
+    if admin_user and not update:
+        raise click.ClickException(
+            "Dev Admin already exists. Re-run with --update to replace the password."
+        )
+
+    if admin_user is None:
+        admin_user = AdminUser(email=normalized_email)
+        db.session.add(admin_user)
+        action = "created"
+    else:
+        action = "updated"
+
+    comparison_time = utc_now()
+    admin_user.full_name = (full_name or "").strip() or None
+    admin_user.set_role(ROLE_DEV_ADMIN, now=comparison_time)
+    admin_user.set_account_status(ACCOUNT_STATUS_ACTIVE, now=comparison_time)
+    admin_user.reset_login_state()
+    admin_user.set_password(password)
+    admin_user.sync_legacy_state()
+    db.session.commit()
+
+    click.echo(f"Dev Admin {action}: {normalized_email}")
+
+
+@app.cli.command("backfill-admin-access")
+@click.option(
+    "--first-superadmin-email",
+    default=None,
+    help="Email address to assign the first Superadmin role during backfill.",
+)
+@click.option(
+    "--dev-admin-email",
+    "dev_admin_emails",
+    multiple=True,
+    help="Email addresses to mark as hidden Dev Admin accounts during backfill.",
+)
+def backfill_admin_access_command(first_superadmin_email, dev_admin_emails):
+    db.create_all(bind_key=AUTH_BIND_KEY)
+    ensure_admin_user_access_columns()
+    selected_superadmin_email = normalize_email(first_superadmin_email)
+    selected_dev_admin_emails = {normalize_email(email) for email in dev_admin_emails}
+    comparison_time = utc_now()
+    admin_users = AdminUser.query.order_by(AdminUser.created_at.asc()).all()
+
+    for admin_user in admin_users:
+        if admin_user.email in selected_dev_admin_emails:
+            admin_user.set_role(ROLE_DEV_ADMIN, now=comparison_time)
+            admin_user.set_account_status(
+                ACCOUNT_STATUS_ACTIVE if admin_user.is_active else ACCOUNT_STATUS_SUSPENDED,
+                now=comparison_time,
+            )
+        else:
+            admin_user.set_role(
+                ROLE_SUPERADMIN
+                if selected_superadmin_email and admin_user.email == selected_superadmin_email
+                else admin_user.role
+                or ROLE_STAFF_OPERATOR,
+                now=comparison_time,
+            )
+            admin_user.set_account_status(
+                ACCOUNT_STATUS_ACTIVE if admin_user.is_active else ACCOUNT_STATUS_SUSPENDED,
+                now=comparison_time,
+            )
+        admin_user.sync_legacy_state()
+
+    active_superadmin_count = AdminUser.query.filter(
+        AdminUser.role == ROLE_SUPERADMIN,
+        AdminUser.account_status == ACCOUNT_STATUS_ACTIVE,
+    ).count()
+    if active_superadmin_count == 0:
+        raise click.ClickException(
+            "Backfill would leave zero active superadmins. Re-run with --first-superadmin-email."
+        )
+
+    db.session.commit()
+    click.echo("Admin access backfill completed.")
 
 
 @app.cli.command("seed-dev-admin")
 def seed_dev_admin_command():
     require_dev_test_admin_mode()
 
-    db.create_all(bind_key=[AUTH_BIND_KEY])
+    db.create_all(bind_key=AUTH_BIND_KEY)
+    ensure_admin_user_access_columns()
     admin_user = AdminUser.query.filter_by(email=DEV_TEST_ADMIN_EMAIL).first()
 
     if admin_user is None:
@@ -845,10 +2059,13 @@ def seed_dev_admin_command():
     else:
         action = "updated"
 
+    comparison_time = utc_now()
     admin_user.full_name = DEV_TEST_ADMIN_FULL_NAME
-    admin_user.is_active = True
+    admin_user.set_role(ROLE_DEV_ADMIN, now=comparison_time)
+    admin_user.set_account_status(ACCOUNT_STATUS_ACTIVE, now=comparison_time)
     admin_user.reset_login_state()
     admin_user.set_password(DEV_TEST_ADMIN_PASSWORD)
+    admin_user.sync_legacy_state()
     db.session.commit()
 
     click.echo(f"Dev test admin {action}: {DEV_TEST_ADMIN_EMAIL}")

--- a/templates/access_denied.html
+++ b/templates/access_denied.html
@@ -1,0 +1,17 @@
+{% extends "base_authenticated.html" %}
+
+{% block title %}{{ page_title }} | ShyneBeauty{% endblock %}
+{% block page_title %}{{ page_title }}{% endblock %}
+{% block page_description %}
+  <p>{{ denial_message }}</p>
+{% endblock %}
+
+{% block content %}
+  <section class="sb-panel">
+    <h2>What to do next</h2>
+    <p class="sb-section-note">
+      If you expected access, contact a Superadmin for business access changes or a
+      Dev Admin for technical console access.
+    </p>
+  </section>
+{% endblock %}

--- a/templates/base_authenticated.html
+++ b/templates/base_authenticated.html
@@ -1,0 +1,717 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}ShyneBeauty{% endblock %}</title>
+  <style>
+    :root {
+      --sb-bg: #f6f3ee;
+      --sb-surface: #fffdf9;
+      --sb-surface-alt: #fcf8f2;
+      --sb-border: #dacdbb;
+      --sb-border-strong: #c8b69e;
+      --sb-text: #4f4a45;
+      --sb-text-soft: #756d65;
+      --sb-accent: #9ecfc7;
+      --sb-accent-soft: #dff0ec;
+      --sb-accent-strong: #5f7d78;
+      --sb-warn-bg: #f3e3d0;
+      --sb-warn-text: #6f5131;
+      --sb-error-bg: #f6ddd5;
+      --sb-error-text: #7b4a3e;
+      --sb-success-bg: #e0efe4;
+      --sb-success-text: #3f5c47;
+      --sb-shadow: 0 2px 8px rgba(87, 71, 53, 0.08);
+      --sb-radius: 10px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      min-height: 100%;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Raleway", sans-serif;
+      background: var(--sb-bg);
+      color: var(--sb-text);
+      line-height: 1.5;
+    }
+
+    a,
+    button,
+    input,
+    select,
+    textarea {
+      font: inherit;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .sb-skip-link {
+      position: absolute;
+      left: 16px;
+      top: 16px;
+      z-index: 1000;
+      padding: 10px 14px;
+      background: var(--sb-surface);
+      border: 1px solid var(--sb-border-strong);
+      border-radius: 8px;
+      transform: translateY(-160%);
+      transition: transform 0.15s ease;
+      text-decoration: none;
+    }
+
+    .sb-skip-link:focus {
+      transform: translateY(0);
+    }
+
+    .sb-shell {
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 256px 1fr;
+      grid-template-rows: auto 1fr;
+      grid-template-areas:
+        "sidebar header"
+        "sidebar main";
+    }
+
+    .sb-header {
+      grid-area: header;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px 24px;
+      background: rgba(246, 243, 238, 0.96);
+      border-bottom: 1px solid var(--sb-border);
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(6px);
+    }
+
+    .sb-menu-button,
+    .sb-button,
+    .sb-button-secondary,
+    .sb-button-danger,
+    .sb-button-link {
+      border: 1px solid var(--sb-border-strong);
+      border-radius: 8px;
+      padding: 9px 12px;
+      background: var(--sb-surface);
+      color: var(--sb-text);
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
+
+    .sb-menu-button {
+      display: none;
+    }
+
+    .sb-button,
+    .sb-button-secondary,
+    .sb-button-danger {
+      min-height: 40px;
+    }
+
+    .sb-button {
+      background: var(--sb-accent-soft);
+      border-color: #aacdc6;
+    }
+
+    .sb-button-secondary {
+      background: var(--sb-surface-alt);
+    }
+
+    .sb-button-danger {
+      background: var(--sb-error-bg);
+      border-color: #dfb9ae;
+      color: var(--sb-error-text);
+    }
+
+    .sb-button-link {
+      background: transparent;
+      border-color: transparent;
+      padding-inline: 0;
+    }
+
+    .sb-header-brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .sb-header-brand img,
+    .sb-sidebar-brand img {
+      width: 40px;
+      height: 40px;
+      object-fit: cover;
+      border-radius: 10px;
+    }
+
+    .sb-header-account {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      justify-content: flex-end;
+    }
+
+    .sb-header-account-copy {
+      display: grid;
+      gap: 2px;
+      text-align: right;
+    }
+
+    .sb-header-account-copy strong {
+      font-size: 14px;
+    }
+
+    .sb-header-account-copy span {
+      color: var(--sb-text-soft);
+      font-size: 13px;
+    }
+
+    .sb-sidebar {
+      grid-area: sidebar;
+      background: var(--sb-surface-alt);
+      border-right: 1px solid var(--sb-border);
+      padding: 24px 18px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .sb-sidebar-brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      text-decoration: none;
+      font-weight: 700;
+    }
+
+    .sb-sidebar-brand-copy {
+      display: grid;
+      gap: 2px;
+    }
+
+    .sb-sidebar-brand-copy small {
+      color: var(--sb-text-soft);
+      font-size: 12px;
+    }
+
+    .sb-sidebar-nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 6px;
+    }
+
+    .sb-sidebar-nav a {
+      display: block;
+      padding: 10px 12px;
+      border-radius: 8px;
+      text-decoration: none;
+      color: var(--sb-text);
+    }
+
+    .sb-sidebar-nav a[aria-current="page"] {
+      background: var(--sb-accent-soft);
+      font-weight: 700;
+    }
+
+    .sb-sidebar-nav a:hover,
+    .sb-sidebar-nav a:focus-visible {
+      background: #efe7dc;
+    }
+
+    .sb-sidebar-footer {
+      margin-top: auto;
+      color: var(--sb-text-soft);
+      font-size: 13px;
+    }
+
+    .sb-main {
+      grid-area: main;
+      padding: 28px 24px 40px;
+    }
+
+    .sb-page-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 20px;
+    }
+
+    .sb-page-header h1 {
+      margin: 0;
+      font-size: 30px;
+      line-height: 1.15;
+    }
+
+    .sb-page-header p {
+      margin: 8px 0 0;
+      color: var(--sb-text-soft);
+      max-width: 64ch;
+    }
+
+    .sb-page-actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .sb-flash-stack {
+      display: grid;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .sb-flash {
+      padding: 12px 14px;
+      border-radius: 8px;
+      border: 1px solid var(--sb-border);
+      background: var(--sb-surface);
+    }
+
+    .sb-flash-error {
+      background: var(--sb-error-bg);
+      color: var(--sb-error-text);
+      border-color: #dfb9ae;
+    }
+
+    .sb-flash-success {
+      background: var(--sb-success-bg);
+      color: var(--sb-success-text);
+      border-color: #bfd4c5;
+    }
+
+    .sb-flash-info {
+      background: var(--sb-accent-soft);
+      color: #47635f;
+      border-color: #bed9d4;
+    }
+
+    .sb-panel {
+      background: var(--sb-surface);
+      border: 1px solid var(--sb-border);
+      border-radius: var(--sb-radius);
+      box-shadow: var(--sb-shadow);
+      padding: 18px;
+    }
+
+    .sb-panel + .sb-panel {
+      margin-top: 16px;
+    }
+
+    .sb-panel h2,
+    .sb-panel h3 {
+      margin: 0 0 12px;
+      font-size: 18px;
+    }
+
+    .sb-grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .sb-grid-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .sb-grid-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .sb-grid-4 {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .sb-metric {
+      display: grid;
+      gap: 4px;
+    }
+
+    .sb-metric strong {
+      font-size: 28px;
+    }
+
+    .sb-metric span {
+      color: var(--sb-text-soft);
+    }
+
+    .sb-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 10px;
+    }
+
+    .sb-list li {
+      padding-bottom: 10px;
+      border-bottom: 1px solid #eee4d6;
+    }
+
+    .sb-list li:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .sb-form-grid {
+      display: grid;
+      gap: 14px;
+    }
+
+    .sb-form-row {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .sb-field {
+      display: grid;
+      gap: 6px;
+    }
+
+    .sb-field label {
+      font-size: 14px;
+      font-weight: 700;
+    }
+
+    .sb-input,
+    .sb-select,
+    .sb-textarea {
+      min-height: 42px;
+      width: 100%;
+      border: 1px solid var(--sb-border-strong);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #fffdfb;
+      color: var(--sb-text);
+    }
+
+    .sb-textarea {
+      min-height: 110px;
+      resize: vertical;
+    }
+
+    .sb-form-actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .sb-data-table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 680px;
+    }
+
+    .sb-data-table caption {
+      text-align: left;
+      margin-bottom: 12px;
+      color: var(--sb-text-soft);
+    }
+
+    .sb-data-table th,
+    .sb-data-table td {
+      text-align: left;
+      padding: 12px 10px;
+      border-bottom: 1px solid #ece2d5;
+      vertical-align: top;
+    }
+
+    .sb-data-table th {
+      color: var(--sb-text-soft);
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .sb-table-wrap {
+      overflow-x: auto;
+    }
+
+    .sb-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: 6px;
+      background: var(--sb-surface-alt);
+      border: 1px solid #e4d6c7;
+      font-size: 13px;
+    }
+
+    .sb-status-active {
+      background: var(--sb-success-bg);
+      border-color: #bfd4c5;
+      color: var(--sb-success-text);
+    }
+
+    .sb-status-pending,
+    .sb-status-expired,
+    .sb-status-locked {
+      background: var(--sb-warn-bg);
+      border-color: #dcc1a0;
+      color: var(--sb-warn-text);
+    }
+
+    .sb-status-suspended,
+    .sb-status-danger {
+      background: var(--sb-error-bg);
+      border-color: #dfb9ae;
+      color: var(--sb-error-text);
+    }
+
+    .sb-meta-list {
+      display: grid;
+      gap: 10px;
+      margin: 0;
+    }
+
+    .sb-meta-list div {
+      display: grid;
+      gap: 2px;
+    }
+
+    .sb-meta-list dt {
+      color: var(--sb-text-soft);
+      font-size: 13px;
+    }
+
+    .sb-meta-list dd {
+      margin: 0;
+    }
+
+    .sb-section-note,
+    .sb-empty {
+      color: var(--sb-text-soft);
+    }
+
+    .sb-inline-note {
+      font-size: 13px;
+      color: var(--sb-text-soft);
+    }
+
+    .sb-danger-zone {
+      border-top: 1px solid #e8d9cd;
+      padding-top: 16px;
+      margin-top: 16px;
+    }
+
+    .sb-danger-zone h3 {
+      color: var(--sb-error-text);
+    }
+
+    .sb-pill-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    .sb-pill-list li {
+      padding: 5px 9px;
+      border-radius: 6px;
+      border: 1px solid #ddcfbd;
+      background: var(--sb-surface-alt);
+      font-size: 13px;
+    }
+
+    :focus-visible {
+      outline: 3px solid rgba(95, 125, 120, 0.32);
+      outline-offset: 2px;
+    }
+
+    .sb-mobile-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(54, 44, 31, 0.28);
+      z-index: 15;
+    }
+
+    @media (max-width: 980px) {
+      .sb-shell {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+          "header"
+          "main";
+      }
+
+      .sb-sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: min(290px, calc(100vw - 32px));
+        transform: translateX(-105%);
+        transition: transform 0.15s ease;
+        z-index: 30;
+      }
+
+      .sb-sidebar[data-open="true"] {
+        transform: translateX(0);
+      }
+
+      .sb-mobile-overlay[data-open="true"] {
+        display: block;
+      }
+
+      .sb-menu-button {
+        display: inline-flex;
+      }
+
+      .sb-header {
+        grid-area: header;
+      }
+
+      .sb-main {
+        padding: 20px 16px 32px;
+      }
+
+      .sb-page-header,
+      .sb-header-account,
+      .sb-form-row,
+      .sb-grid-2,
+      .sb-grid-3,
+      .sb-grid-4 {
+        grid-template-columns: 1fr;
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .sb-page-actions {
+        justify-content: flex-start;
+      }
+    }
+  </style>
+  {% block head_extra %}{% endblock %}
+</head>
+<body>
+  <a class="sb-skip-link" href="#main-content">Skip to main content</a>
+  <div class="sb-mobile-overlay" id="sb-mobile-overlay" hidden></div>
+  <div class="sb-shell">
+    <header class="sb-header">
+      <div style="display:flex;align-items:center;gap:12px;">
+        <button
+          class="sb-menu-button"
+          id="sb-menu-button"
+          type="button"
+          aria-expanded="false"
+          aria-controls="sb-sidebar"
+        >
+          Menu
+        </button>
+        <a class="sb-header-brand" href="{{ url_for('index') }}">
+          <img src="{{ url_for('static', filename='shyneIcon.png') }}" alt="">
+          <span>ShyneBeauty</span>
+        </a>
+      </div>
+      <div class="sb-header-account">
+        <div class="sb-header-account-copy">
+          <strong>{{ current_admin_label }}</strong>
+          <span>{{ current_admin_role_label }}</span>
+        </div>
+        <form method="post" action="{{ url_for('logout') }}">
+          <button class="sb-button-secondary" type="submit">Log out</button>
+        </form>
+      </div>
+    </header>
+
+    <nav class="sb-sidebar" id="sb-sidebar" aria-label="Primary">
+      <a class="sb-sidebar-brand" href="{{ url_for('index') }}">
+        <img src="{{ url_for('static', filename='shyneIcon.png') }}" alt="">
+        <span class="sb-sidebar-brand-copy">
+          <span>ShyneBeauty</span>
+          <small>Internal operations</small>
+        </span>
+      </a>
+      <div class="sb-sidebar-nav">
+        <ul>
+          {% for item in authenticated_nav_items %}
+            <li>
+              <a
+                href="{{ url_for(item.endpoint) }}"
+                {% if request.endpoint == item.endpoint %}aria-current="page"{% endif %}
+              >
+                {{ item.label }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+      <p class="sb-sidebar-footer">Protected internal workspace</p>
+    </nav>
+
+    <main class="sb-main" id="main-content">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="sb-flash-stack" aria-live="polite">
+            {% for category, message in messages %}
+              <div class="sb-flash sb-flash-{{ category }}">{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+
+      <div class="sb-page-header">
+        <div>
+          <h1>{% block page_title %}{% endblock %}</h1>
+          {% block page_description %}{% endblock %}
+        </div>
+        <div class="sb-page-actions">
+          {% block page_actions %}{% endblock %}
+        </div>
+      </div>
+
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+
+  <script>
+    const sidebar = document.getElementById("sb-sidebar");
+    const overlay = document.getElementById("sb-mobile-overlay");
+    const menuButton = document.getElementById("sb-menu-button");
+
+    if (sidebar && overlay && menuButton) {
+      const toggleSidebar = (open) => {
+        sidebar.dataset.open = open ? "true" : "false";
+        overlay.dataset.open = open ? "true" : "false";
+        overlay.hidden = !open;
+        menuButton.setAttribute("aria-expanded", open ? "true" : "false");
+      };
+
+      menuButton.addEventListener("click", () => {
+        toggleSidebar(menuButton.getAttribute("aria-expanded") !== "true");
+      });
+      overlay.addEventListener("click", () => toggleSidebar(false));
+      window.addEventListener("resize", () => {
+        if (window.innerWidth > 980) {
+          toggleSidebar(false);
+        }
+      });
+    }
+  </script>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,22 @@
+{% extends "base_authenticated.html" %}
+
+{% block title %}Users & Access{% endblock %}
+
+{% block content %}
+  <section class="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6">
+    <header class="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm">
+      <h1 class="text-2xl font-semibold text-stone-900">Users &amp; Access</h1>
+      <p class="mt-2 max-w-3xl text-sm text-stone-600">
+        Fixed-role access management is available on this branch. The fuller table and onboarding
+        UI are layered in later stacked branches.
+      </p>
+    </header>
+
+    <section class="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-stone-900">Current scope</h2>
+      <p class="mt-2 text-sm text-stone-600">
+        Superadmins manage business access here. The hidden Dev Admin role remains outside this surface.
+      </p>
+    </section>
+  </section>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,15 @@ os.environ.setdefault(
 )
 
 from shyne import AdminUser
+from shyne import ACCOUNT_STATUS_ACTIVE
+from shyne import ACCOUNT_STATUS_INVITED
+from shyne import ACCOUNT_STATUS_SUSPENDED
+from shyne import ROLE_DEV_ADMIN
+from shyne import ROLE_STAFF_OPERATOR
+from shyne import ROLE_SUPERADMIN
 from shyne import app as flask_app
 from shyne import db
+from shyne import utc_now
 
 
 @pytest.fixture()
@@ -88,6 +95,92 @@ def admin_user(app):
             full_name="Shyne Admin",
         )
         user.set_password("correct-horse-battery-staple")
+        user.set_role(ROLE_SUPERADMIN, now=utc_now())
+        user.set_account_status(ACCOUNT_STATUS_ACTIVE, now=utc_now())
         db.session.add(user)
         db.session.commit()
+        return user.id
+
+
+@pytest.fixture()
+def admin_factory(app):
+    with app.app_context():
+        created_count = {"value": 0}
+
+        def _create_admin(
+            *,
+            email=None,
+            full_name="Shyne Admin",
+            password="correct-horse-battery-staple",
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_ACTIVE,
+            failed_login_count=0,
+            locked_until=None,
+            last_login_at=None,
+            permission_overrides=None,
+        ):
+            created_count["value"] += 1
+            comparison_time = utc_now()
+            user = AdminUser(
+                email=email or f"admin{created_count['value']}@shynebeauty.com",
+                full_name=full_name,
+                failed_login_count=failed_login_count,
+                locked_until=locked_until,
+                last_login_at=last_login_at,
+            )
+            if password is not None:
+                user.set_password(password)
+            else:
+                user.password_hash = ""
+            if role is not None:
+                user.set_role(role, now=comparison_time)
+            if account_status is not None:
+                user.set_account_status(account_status, now=comparison_time)
+            else:
+                user.account_status = None
+                user.is_active = True
+            if account_status == ACCOUNT_STATUS_INVITED:
+                user.invited_by_user_id = 1
+            if permission_overrides is not None:
+                user.set_permission_overrides(permission_overrides)
+            db.session.add(user)
+            db.session.commit()
+            return user
+
+        yield _create_admin
+
+
+@pytest.fixture()
+def staff_user(app, admin_factory):
+    with app.app_context():
+        user = admin_factory(
+            email="staff@shynebeauty.com",
+            full_name="Staff User",
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_ACTIVE,
+        )
+        return user.id
+
+
+@pytest.fixture()
+def dev_admin_user(app, admin_factory):
+    with app.app_context():
+        user = admin_factory(
+            email="devadmin@shynebeauty.com",
+            full_name="Dev Admin",
+            role=ROLE_DEV_ADMIN,
+            account_status=ACCOUNT_STATUS_ACTIVE,
+        )
+        return user.id
+
+
+@pytest.fixture()
+def suspended_user(app, admin_factory):
+    with app.app_context():
+        user = admin_factory(
+            email="suspended@shynebeauty.com",
+            full_name="Suspended User",
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_SUSPENDED,
+        )
         return user.id

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from sqlalchemy import inspect, text
 
 from shyne import (
+    ACCOUNT_STATUS_ACTIVE,
     AdminUser,
     Batch,
+    AdminAccessEvent,
     BatchIngredient,
     Customer,
     Ingredient,
@@ -19,6 +21,8 @@ from shyne import (
     PASSWORD_HASH_METHOD,
     Product,
     ProductBatch,
+    ROLE_DEV_ADMIN,
+    ROLE_SUPERADMIN,
     Shipment,
     db,
     load_project_env,
@@ -150,6 +154,8 @@ def test_routes_are_registered(app):
     assert "/login" in routes
     assert "/orders" in routes
     assert "/customers" in routes
+    assert "/inventory" in routes
+    assert "/users" in routes
     assert "/tasks" in routes
     assert "/logout" in routes
 
@@ -182,6 +188,17 @@ def test_init_db_cli_command_creates_tables_and_reports_success(app):
     }
     assert "admin_users" not in set(primary_inspector.get_table_names())
     assert "admin_users" in set(auth_inspector.get_table_names())
+    assert "admin_access_events" in set(auth_inspector.get_table_names())
+    assert {
+        column["name"] for column in auth_inspector.get_columns("admin_users")
+    } >= {
+        "role",
+        "account_status",
+        "invited_at",
+        "invited_by_user_id",
+        "activated_at",
+        "permission_overrides_json",
+    }
 
 
 def test_init_db_cli_command_is_idempotent(app):
@@ -249,6 +266,8 @@ def test_create_admin_cli_command_creates_hashed_password(app):
         assert user.password_hash != password
         assert user.password_hash.startswith(f"{PASSWORD_HASH_METHOD}$")
         assert user.check_password(password) is True
+        assert user.get_role() == ROLE_SUPERADMIN
+        assert user.get_account_status() == ACCOUNT_STATUS_ACTIVE
         assert "admin_users" not in set(inspect(db.engine).get_table_names())
         assert "admin_users" in set(inspect(db.engines["auth"]).get_table_names())
 
@@ -314,12 +333,59 @@ def test_seed_dev_admin_cli_command_upserts_dev_admin(app):
         user = AdminUser.query.filter_by(email="admin").one()
         assert user.full_name == "Dev Admin"
         assert user.is_active is True
+        assert user.get_role() == ROLE_DEV_ADMIN
         assert user.failed_login_count == 0
         assert user.locked_until is None
         assert user.password_hash != "admin"
         assert user.password_hash.startswith(f"{PASSWORD_HASH_METHOD}$")
         assert user.check_password("admin") is True
         assert AdminUser.query.filter_by(email="admin").count() == 1
+
+
+def test_create_dev_admin_cli_command_creates_hidden_dev_admin(app):
+    runner = app.test_cli_runner()
+    password = "StrongPassw0rd!"
+
+    result = runner.invoke(
+        args=["create-dev-admin", "--email", "tech@shynebeauty.com"],
+        input=f"{password}\n{password}\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Dev Admin created: tech@shynebeauty.com" in result.output
+
+    with app.app_context():
+        user = AdminUser.query.filter_by(email="tech@shynebeauty.com").one()
+        assert user.get_role() == ROLE_DEV_ADMIN
+        assert user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+
+
+def test_backfill_admin_access_requires_explicit_superadmin_assignment(app, admin_factory):
+    with app.app_context():
+        admin_factory(
+            email="legacy@shynebeauty.com",
+            full_name="Legacy Admin",
+            role=None,
+            account_status=None,
+        )
+
+    runner = app.test_cli_runner()
+    failure = runner.invoke(args=["backfill-admin-access"])
+    success = runner.invoke(
+        args=[
+            "backfill-admin-access",
+            "--first-superadmin-email",
+            "legacy@shynebeauty.com",
+        ]
+    )
+
+    assert failure.exit_code != 0
+    assert "zero active superadmins" in failure.output
+    assert success.exit_code == 0
+
+    with app.app_context():
+        user = AdminUser.query.filter_by(email="legacy@shynebeauty.com").one()
+        assert user.get_role() == ROLE_SUPERADMIN
 
 
 def test_model_defaults_and_relationships_round_trip(app):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,12 +1,14 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import inspect, select, text
 
-from shyne import AdminUser, db
+from shyne import AUTH_BIND_KEY, ACCOUNT_STATUS_ACTIVE, AdminUser, ROLE_STAFF_OPERATOR, ROLE_SUPERADMIN, db
 
 
-@pytest.mark.parametrize("route", ["/", "/orders", "/tasks", "/customers", "/admin/"])
+@pytest.mark.parametrize(
+    "route", ["/", "/orders", "/tasks", "/customers", "/inventory", "/users", "/admin/"]
+)
 def test_anonymous_access_to_protected_routes_redirects_to_login(client, route):
     response = client.get(route)
 
@@ -331,7 +333,8 @@ def test_seeded_dev_test_admin_still_locks_after_repeated_failed_attempts(client
         ("/orders", b"Manage Orders"),
         ("/tasks", b"Task List"),
         ("/customers", b"Customer Database"),
-        ("/admin/", b"ShyneBeauty Admin"),
+        ("/inventory", b"Inventory Page"),
+        ("/users", b"Users & Access"),
     ],
 )
 def test_authenticated_users_can_reach_protected_routes(
@@ -345,3 +348,139 @@ def test_authenticated_users_can_reach_protected_routes(
     assert response.headers["Cache-Control"] == "no-store"
     assert response.content_type.startswith("text/html")
     assert expected_text in response.data
+
+
+def test_superadmin_is_denied_admin_console_access(client, admin_user, login):
+    login(client)
+
+    response = client.get("/admin/")
+
+    assert response.status_code == 403
+    assert b"Admin console access denied" in response.data
+
+
+def test_staff_operator_is_denied_users_access(client, staff_user, login):
+    response = login(
+        client,
+        email="staff@shynebeauty.com",
+        password="correct-horse-battery-staple",
+    )
+
+    assert response.status_code == 302
+
+    denied_response = client.get("/users")
+
+    assert denied_response.status_code == 403
+    assert b"Users &amp; Access denied" in denied_response.data
+
+
+def test_dev_admin_can_access_admin_console_but_not_users(client, dev_admin_user, login):
+    response = login(
+        client,
+        email="devadmin@shynebeauty.com",
+        password="correct-horse-battery-staple",
+    )
+
+    assert response.status_code == 302
+
+    admin_response = client.get("/admin/")
+    users_response = client.get("/users")
+
+    assert admin_response.status_code == 200
+    assert b"ShyneBeauty Admin" in admin_response.data
+    assert users_response.status_code == 403
+    assert b"Users &amp; Access denied" in users_response.data
+
+
+def test_runtime_auth_schema_compatibility_upgrades_legacy_admin_table_before_user_load(
+    client, app
+):
+    try:
+        with app.app_context():
+            db.session.remove()
+            db.drop_all(bind_key=AUTH_BIND_KEY)
+            auth_engine = db.engines[AUTH_BIND_KEY]
+            with auth_engine.begin() as connection:
+                connection.execute(
+                    text(
+                        """
+                        CREATE TABLE admin_users (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            email VARCHAR(255) NOT NULL UNIQUE,
+                            password_hash VARCHAR(255),
+                            full_name VARCHAR(255),
+                            is_active BOOLEAN NOT NULL DEFAULT 1,
+                            failed_login_count INTEGER NOT NULL DEFAULT 0,
+                            locked_until DATETIME,
+                            last_login_at DATETIME,
+                            created_at DATETIME NOT NULL
+                        )
+                        """
+                    )
+                )
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO admin_users (
+                            id,
+                            email,
+                            password_hash,
+                            full_name,
+                            is_active,
+                            failed_login_count,
+                            locked_until,
+                            last_login_at,
+                            created_at
+                        ) VALUES (
+                            :id,
+                            :email,
+                            :password_hash,
+                            :full_name,
+                            :is_active,
+                            :failed_login_count,
+                            :locked_until,
+                            :last_login_at,
+                            :created_at
+                        )
+                        """
+                    ),
+                    {
+                        "id": 1,
+                        "email": "legacy@shynebeauty.com",
+                        "password_hash": "legacy-hash",
+                        "full_name": "Legacy Admin",
+                        "is_active": True,
+                        "failed_login_count": 0,
+                        "locked_until": None,
+                        "last_login_at": None,
+                        "created_at": datetime.now(timezone.utc),
+                    },
+                )
+
+        with client.session_transaction() as session_data:
+            session_data["_user_id"] = "1"
+            session_data["_fresh"] = True
+
+        response = client.get("/")
+
+        assert response.status_code == 200
+        assert b"Home Dashboard / Analytics" in response.data
+
+        with app.app_context():
+            auth_inspector = inspect(db.engines[AUTH_BIND_KEY])
+            assert "admin_access_events" in set(auth_inspector.get_table_names())
+            assert {
+                column["name"] for column in auth_inspector.get_columns("admin_users")
+            } >= {
+                "role",
+                "account_status",
+                "permission_overrides_json",
+            }
+            user = db.session.get(AdminUser, 1)
+            assert user.get_role() == "Staff Operator"
+            assert user.get_account_status() == "active"
+    finally:
+        with app.app_context():
+            db.session.remove()
+            db.drop_all(bind_key=AUTH_BIND_KEY)
+            db.create_all(bind_key=AUTH_BIND_KEY)


### PR DESCRIPTION
- add the fixed-role admin access foundation for ShyneBeauty
- split business access management (`/users`) from the technical admin console (`/admin/`)
- add runtime auth-schema compatibility for older auth databases
- add the shared authenticated shell and access-denied surface for protected pages
-
- this PR is the backend/auth foundation only
- the richer `/users` management UI is layered in a later stacked PR
- temporary-password onboarding and forced password change are handled in a later stacked PR