### PR TITLE
Require password change after temporary password login

### DIFF
--- a/shyne.py
+++ b/shyne.py
@@ -1,5 +1,7 @@
 import json
 import os
+import secrets
+import string
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 from pathlib import Path
@@ -201,7 +203,9 @@ ADMIN_ACCESS_EVENT_INVITE_CREATED = "invite.created"
 ADMIN_ACCESS_EVENT_INVITE_RESENT = "invite.resent"
 ADMIN_ACCESS_EVENT_INVITE_CANCELLED = "invite.cancelled"
 ADMIN_ACCESS_EVENT_ACCOUNT_ACTIVATED = "account.activated"
+ADMIN_ACCESS_EVENT_ACCOUNT_CREATED = "account.created"
 ADMIN_ACCESS_EVENT_PASSWORD_RESET = "account.password_reset"
+ADMIN_ACCESS_EVENT_PASSWORD_CHANGED = "account.password_changed"
 ADMIN_ACCESS_EVENT_ROLE_CHANGED = "account.role_changed"
 ADMIN_ACCESS_EVENT_STATUS_CHANGED = "account.status_changed"
 ADMIN_ACCESS_EVENT_ACCESS_DENIED = "access.denied"
@@ -214,6 +218,7 @@ SECURITY_HEADERS = {
 }
 NO_STORE_ENDPOINTS = {
     "index",
+    "change_password",
     "login",
     "logout",
     "orders",
@@ -326,6 +331,11 @@ def current_request_next_target():
     return request.path
 
 
+def generate_temporary_password(length=16):
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
 def slug_to_role_label(value):
     if value not in ROLE_SLUG_MAP:
         raise click.ClickException(
@@ -435,6 +445,10 @@ def ensure_admin_user_access_columns():
         "last_role_changed_at": "ALTER TABLE admin_users ADD COLUMN last_role_changed_at DATETIME",
         "last_role_changed_by_user_id": "ALTER TABLE admin_users ADD COLUMN last_role_changed_by_user_id INTEGER",
         "permission_overrides_json": "ALTER TABLE admin_users ADD COLUMN permission_overrides_json TEXT",
+        "must_change_password": (
+            "ALTER TABLE admin_users "
+            "ADD COLUMN must_change_password BOOLEAN NOT NULL DEFAULT 0"
+        ),
     }
 
     with auth_engine.begin() as connection:
@@ -492,6 +506,7 @@ class AdminUser(UserMixin, db.Model):
     last_role_changed_at = db.Column(db.DateTime(timezone=True))
     last_role_changed_by_user_id = db.Column(db.Integer)
     permission_overrides_json = db.Column(db.Text)
+    must_change_password = db.Column(db.Boolean, nullable=False, default=False)
     failed_login_count = db.Column(db.Integer, nullable=False, default=0)
     locked_until = db.Column(db.DateTime(timezone=True))
     last_login_at = db.Column(db.DateTime(timezone=True))
@@ -617,6 +632,9 @@ class AdminUser(UserMixin, db.Model):
     def reset_login_state(self):
         self.failed_login_count = 0
         self.locked_until = None
+
+    def requires_password_change(self):
+        return bool(self.must_change_password)
 
     def display_status(self, now=None):
         if self.is_locked(now):
@@ -883,6 +901,7 @@ def serialize_admin_user_snapshot(admin_user, *, now=None):
         "display_status": admin_user.display_status(comparison_time),
         "is_active": bool(admin_user.is_active),
         "is_locked": admin_user.is_locked(comparison_time),
+        "must_change_password": admin_user.requires_password_change(),
         "permission_overrides": admin_user.get_permission_overrides(),
     }
 
@@ -968,6 +987,14 @@ def role_scope_summary(role_label):
     }.get(role_label, "Operational access")
 
 
+def password_state_label(admin_user):
+    return (
+        "Temporary password; must change at next login"
+        if admin_user.requires_password_change()
+        else "Ready for normal sign-in"
+    )
+
+
 def resolve_actor_name(user_id):
     if not user_id:
         return "System"
@@ -975,6 +1002,12 @@ def resolve_actor_name(user_id):
     if admin_user is None:
         return "Unknown user"
     return admin_user.full_name or admin_user.email
+
+
+def force_password_change_allowed_endpoint(endpoint):
+    if endpoint is None:
+        return True
+    return endpoint in {"change_password", "logout", "static"}
 
 
 def parse_last_login_state(admin_user, *, now=None):
@@ -1213,6 +1246,22 @@ def ensure_request_auth_schema_compatibility():
     return None
 
 
+@app.before_request
+def enforce_password_change():
+    if not current_user.is_authenticated:
+        return None
+    if not current_user.requires_password_change():
+        return None
+    if force_password_change_allowed_endpoint(request.endpoint):
+        return None
+
+    next_target = current_request_next_target()
+    safe_next = get_safe_next_target(next_target)
+    if safe_next:
+        return redirect(url_for("change_password", next=safe_next))
+    return redirect(url_for("change_password"))
+
+
 @app.after_request
 def add_security_headers(response):
     for header_name, header_value in SECURITY_HEADERS.items():
@@ -1302,6 +1351,8 @@ def index():
 @app.route("/login", methods=["GET", "POST"])
 def login():
     if current_user.is_authenticated:
+        if current_user.requires_password_change():
+            return redirect(url_for("change_password"))
         return redirect(url_for("index"))
 
     form_data = {"email": "", "remember_me": False}
@@ -1343,6 +1394,10 @@ def login():
 
                 session.clear()
                 login_user(admin_user, remember=remember_me)
+                if admin_user.requires_password_change():
+                    if next_url:
+                        return redirect(url_for("change_password", next=next_url))
+                    return redirect(url_for("change_password"))
                 next_target = request.form.get("next") or request.args.get("next") or ""
                 next_target = next_target.strip()
                 normalized_next_target = next_target.replace("\\", "/")
@@ -1371,6 +1426,53 @@ def login():
         show_dev_test_admin_hint=dev_test_admin_enabled(),
         dev_test_admin_seeded=dev_test_admin_seeded(),
     )
+
+
+@app.route("/change-password", methods=["GET", "POST"])
+def change_password():
+    if not current_user.is_authenticated:
+        return login_manager.unauthorized()
+    if not current_user.requires_password_change():
+        return redirect(url_for("index"))
+
+    next_url = get_safe_next_target(request.args.get("next"))
+    if request.method == "POST":
+        next_url = get_safe_next_target(
+            request.form.get("next") or request.args.get("next")
+        )
+        password = request.form.get("password") or ""
+        password_confirmation = request.form.get("password_confirmation") or ""
+
+        if not password:
+            flash("New password is required.", "error")
+        elif password != password_confirmation:
+            flash("Passwords must match.", "error")
+        elif current_user.check_password(password):
+            flash("Choose a password different from the temporary password.", "error")
+        else:
+            comparison_time = utc_now()
+            before_state = serialize_admin_user_snapshot(
+                current_user, now=comparison_time
+            )
+            current_user.set_password(password)
+            current_user.must_change_password = False
+            current_user.reset_login_state()
+            log_admin_access_event(
+                actor=current_user,
+                target=current_user,
+                event_type=ADMIN_ACCESS_EVENT_PASSWORD_CHANGED,
+                outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
+                before_state=before_state,
+                after_state=serialize_admin_user_snapshot(
+                    current_user, now=comparison_time
+                ),
+                note="Forced password change completed.",
+            )
+            db.session.commit()
+            flash("Password updated.", "success")
+            return redirect(next_url or url_for("index"))
+
+    return render_template("change_password.html", next_url=next_url)
 
 
 @app.route("/orders")
@@ -1562,6 +1664,7 @@ def users():
         ),
         comparison_time=comparison_time,
         permission_labels=summarize_permissions,
+        password_state_label=password_state_label,
         role_scope_summary=role_scope_summary,
         parse_last_login_state=parse_last_login_state,
         resolve_actor_name=resolve_actor_name,
@@ -1576,12 +1679,25 @@ def invite_user():
     email = normalize_email(request.form.get("email"))
     full_name = (request.form.get("full_name") or "").strip()
     role = request.form.get("role")
+    password_mode = (request.form.get("password_mode") or "generated").strip()
+    password = request.form.get("password") or ""
+    password_confirmation = request.form.get("password_confirmation") or ""
     if not email:
         flash("Email is required.", "error")
         return users_redirect_response(show_invite=True, **filter_state)
     if role not in BUSINESS_ROLE_CHOICES:
         flash("Select one of the fixed business roles.", "error")
         return users_redirect_response(show_invite=True, **filter_state)
+    if password_mode not in {"generated", "manual"}:
+        flash("Select a temporary password mode.", "error")
+        return users_redirect_response(show_invite=True, **filter_state)
+    if password_mode == "manual":
+        if not password:
+            flash("Temporary password is required.", "error")
+            return users_redirect_response(show_invite=True, **filter_state)
+        if password != password_confirmation:
+            flash("Passwords must match.", "error")
+            return users_redirect_response(show_invite=True, **filter_state)
     existing_user = AdminUser.query.filter_by(email=email).first()
     if existing_user is not None:
         flash("An account with that email already exists.", "error")
@@ -1592,24 +1708,33 @@ def invite_user():
         email=email,
         full_name=full_name or None,
     )
+    temporary_password = (
+        generate_temporary_password() if password_mode == "generated" else password
+    )
+    created_user.set_password(temporary_password)
+    created_user.must_change_password = True
     created_user.set_role(role, actor=current_user, now=comparison_time)
     created_user.set_account_status(
-        ACCOUNT_STATUS_INVITED, actor=current_user, now=comparison_time
+        ACCOUNT_STATUS_ACTIVE, actor=current_user, now=comparison_time
     )
-    created_user.invited_at = comparison_time
-    created_user.invited_by_user_id = current_user.id
     created_user.reset_login_state()
     db.session.add(created_user)
     db.session.flush()
     log_admin_access_event(
         actor=current_user,
         target=created_user,
-        event_type=ADMIN_ACCESS_EVENT_INVITE_CREATED,
+        event_type=ADMIN_ACCESS_EVENT_ACCOUNT_CREATED,
         outcome=ADMIN_ACCESS_EVENT_OUTCOME_SUCCESS,
         after_state=serialize_admin_user_snapshot(created_user, now=comparison_time),
+        note=f"Temporary password mode: {password_mode}.",
     )
     db.session.commit()
-    flash("Invite created successfully.", "success")
+    flash("User created with a temporary password.", "success")
+    if password_mode == "generated":
+        flash(
+            f"Temporary password (shown once): {temporary_password}",
+            "info",
+        )
     return users_redirect_response(
         selected_user_id=created_user.id,
         show_invite=False,
@@ -1640,6 +1765,7 @@ def activate_user(user_id):
     comparison_time = utc_now()
     before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
     target_user.set_password(password)
+    target_user.must_change_password = True
     target_user.set_account_status(
         ACCOUNT_STATUS_ACTIVE, actor=current_user, now=comparison_time
     )
@@ -1653,7 +1779,7 @@ def activate_user(user_id):
         after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
     )
     db.session.commit()
-    flash("Account activated.", "success")
+    flash("Account activated with a temporary password.", "success")
     return users_redirect_response(selected_user_id=user_id, **filter_state)
 
 
@@ -1844,6 +1970,7 @@ def set_temporary_password(user_id):
     comparison_time = utc_now()
     before_state = serialize_admin_user_snapshot(target_user, now=comparison_time)
     target_user.set_password(password)
+    target_user.must_change_password = True
     target_user.reset_login_state()
     log_admin_access_event(
         actor=current_user,
@@ -1854,7 +1981,7 @@ def set_temporary_password(user_id):
         after_state=serialize_admin_user_snapshot(target_user, now=comparison_time),
     )
     db.session.commit()
-    flash("Password reset successfully.", "success")
+    flash("Temporary password set. The user must change it at next login.", "success")
     return users_redirect_response(selected_user_id=user_id, **filter_state)
 
 

--- a/shyne.py
+++ b/shyne.py
@@ -312,7 +312,7 @@ def is_safe_next_target(target):
     candidate = target.strip()
     normalized_candidate = candidate.replace("\\", "/")
 
-    if not candidate.startswith("/") or normalized_candidate.startswith("//"):
+    if not normalized_candidate.startswith("/") or normalized_candidate.startswith("//"):
         return False
 
     parts = urlparse(normalized_candidate)
@@ -320,8 +320,13 @@ def is_safe_next_target(target):
 
 
 def get_safe_next_target(target):
-    if is_safe_next_target(target):
-        return target.strip()
+    if not target:
+        return ""
+
+    candidate = target.strip()
+    normalized_candidate = candidate.replace("\\", "/")
+    if is_safe_next_target(normalized_candidate):
+        return normalized_candidate
     return ""
 
 
@@ -1398,21 +1403,7 @@ def login():
                     if next_url:
                         return redirect(url_for("change_password", next=next_url))
                     return redirect(url_for("change_password"))
-                next_target = request.form.get("next") or request.args.get("next") or ""
-                next_target = next_target.strip()
-                normalized_next_target = next_target.replace("\\", "/")
-                parsed_next_target = urlparse(normalized_next_target)
-
-                if (
-                    next_target
-                    and next_target.startswith("/")
-                    and not normalized_next_target.startswith("//")
-                    and not parsed_next_target.scheme
-                    and not parsed_next_target.netloc
-                ):
-                    return redirect(normalized_next_target)
-
-                return redirect(url_for("index"))
+                return redirect(next_url or url_for("index"))
             else:
                 if admin_user:
                     admin_user.register_failed_login(now)

--- a/shyne.py
+++ b/shyne.py
@@ -330,6 +330,13 @@ def get_safe_next_target(target):
     return ""
 
 
+def redirect_to_safe_next(target, *, fallback_endpoint="index"):
+    safe_target = get_safe_next_target(target)
+    if safe_target:
+        return redirect(safe_target)
+    return redirect(url_for(fallback_endpoint))
+
+
 def current_request_next_target():
     if request.query_string:
         return f"{request.path}?{request.query_string.decode('utf-8')}"
@@ -1403,7 +1410,10 @@ def login():
                     if next_url:
                         return redirect(url_for("change_password", next=next_url))
                     return redirect(url_for("change_password"))
-                return redirect(next_url or url_for("index"))
+                return redirect_to_safe_next(
+                    request.form.get("next") or request.args.get("next"),
+                    fallback_endpoint="index",
+                )
             else:
                 if admin_user:
                     admin_user.register_failed_login(now)
@@ -1461,7 +1471,10 @@ def change_password():
             )
             db.session.commit()
             flash("Password updated.", "success")
-            return redirect(next_url or url_for("index"))
+            return redirect_to_safe_next(
+                request.form.get("next") or request.args.get("next"),
+                fallback_endpoint="index",
+            )
 
     return render_template("change_password.html", next_url=next_url)
 

--- a/shyne.py
+++ b/shyne.py
@@ -325,7 +325,13 @@ def get_safe_next_target(target):
 
     candidate = target.strip()
     normalized_candidate = candidate.replace("\\", "/")
-    if is_safe_next_target(normalized_candidate):
+    parsed = urlparse(normalized_candidate)
+    if (
+        normalized_candidate.startswith("/")
+        and not normalized_candidate.startswith("//")
+        and not parsed.scheme
+        and not parsed.netloc
+    ):
         return normalized_candidate
     return ""
 

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,30 @@
+{% extends "base_authenticated.html" %}
+
+{% block title %}Change Password{% endblock %}
+{% block page_title %}Change Password{% endblock %}
+{% block page_description %}
+  <p>You must change your temporary password before continuing to the rest of the app.</p>
+{% endblock %}
+
+{% block content %}
+  <section class="sb-panel" style="max-width: 540px;">
+    <h2>Set a new password</h2>
+    <p class="sb-section-note">This account is using a temporary password. Update it now to continue.</p>
+    <form class="sb-form-grid" method="post" action="{{ url_for('change_password') }}">
+      {% if next_url %}
+        <input type="hidden" name="next" value="{{ next_url }}">
+      {% endif %}
+      <div class="sb-field">
+        <label for="change-password">New Password</label>
+        <input class="sb-input" id="change-password" name="password" type="password" autocomplete="new-password" required autofocus>
+      </div>
+      <div class="sb-field">
+        <label for="change-password-confirm">Confirm New Password</label>
+        <input class="sb-input" id="change-password-confirm" name="password_confirmation" type="password" autocomplete="new-password" required>
+      </div>
+      <div class="sb-form-actions">
+        <button class="sb-button" type="submit">Update password</button>
+      </div>
+    </form>
+  </section>
+{% endblock %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -112,14 +112,14 @@
       class="sb-button-secondary"
       href="{{ url_for('users', search=filter_state.search, role_filter=filter_state.role_filter, status_filter=filter_state.status_filter, last_login_filter=filter_state.last_login_filter) }}"
     >
-      Close Invite
+      Close Create User
     </a>
   {% else %}
     <a
       class="sb-button"
       href="{{ url_for('users', search=filter_state.search, role_filter=filter_state.role_filter, status_filter=filter_state.status_filter, last_login_filter=filter_state.last_login_filter, show_invite='1') }}#selected-user-panel"
     >
-      Invite user
+      Create user
     </a>
   {% endif %}
 {% endblock %}
@@ -252,8 +252,8 @@
 
     <aside class="sb-panel sb-inspector" id="selected-user-panel" tabindex="-1" aria-labelledby="selected-user-heading">
       {% if show_invite %}
-        <h2 id="selected-user-heading">Invite user</h2>
-        <p class="sb-section-note">Create an internal account invitation with a fixed business role. `Dev Admin` stays outside this flow.</p>
+        <h2 id="selected-user-heading">Create user</h2>
+        <p class="sb-section-note">Create an active account with a temporary password. The user will be forced to change it on first login.</p>
         <form class="sb-form-grid" method="post" action="{{ url_for('invite_user') }}">
           {{ hidden_filters(filter_state) }}
           <div class="sb-field">
@@ -272,8 +272,26 @@
               {% endfor %}
             </select>
           </div>
+          <div class="sb-field">
+            <label for="password-mode">Temporary Password Mode</label>
+            <select class="sb-select" id="password-mode" name="password_mode">
+              <option value="generated">System generated</option>
+              <option value="manual">Admin entered</option>
+            </select>
+          </div>
+          <div class="sb-field" id="generated-password-note">
+            <span class="sb-inline-note">The app will generate a strong temporary password and show it once after the account is created.</span>
+          </div>
+          <div class="sb-field" id="manual-password-field" hidden>
+            <label for="create-password">Temporary Password</label>
+            <input class="sb-input" id="create-password" name="password" type="password" autocomplete="new-password">
+          </div>
+          <div class="sb-field" id="manual-password-confirm-field" hidden>
+            <label for="create-password-confirm">Confirm Temporary Password</label>
+            <input class="sb-input" id="create-password-confirm" name="password_confirmation" type="password" autocomplete="new-password">
+          </div>
           <div class="sb-form-actions">
-            <button class="sb-button" type="submit">Invite user</button>
+            <button class="sb-button" type="submit">Create user</button>
             <a class="sb-button-secondary" href="{{ url_for('users', search=filter_state.search, role_filter=filter_state.role_filter, status_filter=filter_state.status_filter, last_login_filter=filter_state.last_login_filter) }}">Cancel</a>
           </div>
         </form>
@@ -299,6 +317,10 @@
             <div>
               <dt>Last Login</dt>
               <dd>{{ selected_user.last_login_at or "Never" }}</dd>
+            </div>
+            <div>
+              <dt>Password State</dt>
+              <dd>{{ password_state_label(selected_user) }}</dd>
             </div>
             <div>
               <dt>Created</dt>
@@ -387,15 +409,15 @@
         {% if selected_user.get_account_status() == 'invited' %}
           <section class="sb-inspector-section">
             <h3>Activate Account</h3>
-            <p class="sb-inline-note">Pending invites require an initial password before the user can sign in.</p>
+            <p class="sb-inline-note">Legacy invited account support only. Activation sets a temporary password and requires the user to change it on first login.</p>
             <form class="sb-form-grid" method="post" action="{{ url_for('activate_user', user_id=selected_user.id) }}">
               {{ hidden_filters(filter_state) }}
               <div class="sb-field">
-                <label for="activate-password-{{ selected_user.id }}">Initial Password</label>
+                <label for="activate-password-{{ selected_user.id }}">Temporary Password</label>
                 <input class="sb-input" id="activate-password-{{ selected_user.id }}" name="password" type="password" autocomplete="new-password" required>
               </div>
               <div class="sb-field">
-                <label for="activate-password-confirm-{{ selected_user.id }}">Confirm Password</label>
+                <label for="activate-password-confirm-{{ selected_user.id }}">Confirm Temporary Password</label>
                 <input class="sb-input" id="activate-password-confirm-{{ selected_user.id }}" name="password_confirmation" type="password" autocomplete="new-password" required>
               </div>
               <div class="sb-form-actions">
@@ -407,11 +429,11 @@
 
         {% if selected_user.get_account_status() == 'active' %}
           <section class="sb-inspector-section">
-            <h3>Reset Password</h3>
+            <h3>Set Temporary Password</h3>
             <form class="sb-form-grid" method="post" action="{{ url_for('set_temporary_password', user_id=selected_user.id) }}">
               {{ hidden_filters(filter_state) }}
               <div class="sb-field">
-                <label for="temporary-password-{{ selected_user.id }}">New Password</label>
+                <label for="temporary-password-{{ selected_user.id }}">Temporary Password</label>
                 <input class="sb-input" id="temporary-password-{{ selected_user.id }}" name="password" type="password" autocomplete="new-password" required>
               </div>
               <div class="sb-field">
@@ -419,7 +441,7 @@
                 <input class="sb-input" id="temporary-password-confirm-{{ selected_user.id }}" name="password_confirmation" type="password" autocomplete="new-password" required>
               </div>
               <div class="sb-form-actions">
-                <button class="sb-button-secondary" type="submit">Reset password</button>
+                <button class="sb-button-secondary" type="submit">Set temporary password</button>
               </div>
             </form>
           </section>
@@ -474,6 +496,34 @@
 
 {% block scripts %}
   <script>
+    const passwordModeSelect = document.getElementById("password-mode");
+    const generatedPasswordNote = document.getElementById("generated-password-note");
+    const manualPasswordField = document.getElementById("manual-password-field");
+    const manualPasswordConfirmField = document.getElementById("manual-password-confirm-field");
+    const createPasswordInput = document.getElementById("create-password");
+    const createPasswordConfirmInput = document.getElementById("create-password-confirm");
+
+    if (
+      passwordModeSelect &&
+      generatedPasswordNote &&
+      manualPasswordField &&
+      manualPasswordConfirmField &&
+      createPasswordInput &&
+      createPasswordConfirmInput
+    ) {
+      const syncPasswordMode = () => {
+        const manualMode = passwordModeSelect.value === "manual";
+        generatedPasswordNote.hidden = manualMode;
+        manualPasswordField.hidden = !manualMode;
+        manualPasswordConfirmField.hidden = !manualMode;
+        createPasswordInput.required = manualMode;
+        createPasswordConfirmInput.required = manualMode;
+      };
+
+      passwordModeSelect.addEventListener("change", syncPasswordMode);
+      syncPasswordMode();
+    }
+
     if (window.location.hash === "#selected-user-panel") {
       const panel = document.getElementById("selected-user-panel");
       if (panel) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ def admin_factory(app):
             password="correct-horse-battery-staple",
             role=ROLE_STAFF_OPERATOR,
             account_status=ACCOUNT_STATUS_ACTIVE,
+            must_change_password=False,
             failed_login_count=0,
             locked_until=None,
             last_login_at=None,
@@ -141,6 +142,7 @@ def admin_factory(app):
                 user.is_active = True
             if account_status == ACCOUNT_STATUS_INVITED:
                 user.invited_by_user_id = 1
+            user.must_change_password = must_change_password
             if permission_overrides is not None:
                 user.set_permission_overrides(permission_overrides)
             db.session.add(user)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -156,6 +156,7 @@ def test_routes_are_registered(app):
     assert "/customers" in routes
     assert "/inventory" in routes
     assert "/users" in routes
+    assert "/change-password" in routes
     assert "/tasks" in routes
     assert "/logout" in routes
 
@@ -197,6 +198,7 @@ def test_init_db_cli_command_creates_tables_and_reports_success(app):
         "invited_at",
         "invited_by_user_id",
         "activated_at",
+        "must_change_password",
         "permission_overrides_json",
     }
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -350,6 +350,89 @@ def test_authenticated_users_can_reach_protected_routes(
     assert expected_text in response.data
 
 
+def test_temporary_password_login_redirects_to_forced_password_change(
+    client, admin_factory, login
+):
+    admin_factory(
+        email="temp-user@shynebeauty.com",
+        full_name="Temp User",
+        role=ROLE_STAFF_OPERATOR,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+
+    response = login(
+        client,
+        email="temp-user@shynebeauty.com",
+        password="TempPassw0rd!",
+        next_url="/orders",
+    )
+
+    assert response.status_code == 302
+    assert "/change-password" in response.headers["Location"]
+    assert "next=/orders" in response.headers["Location"]
+
+
+@pytest.mark.parametrize("route", ["/", "/orders", "/customers", "/tasks", "/inventory", "/users", "/admin/"])
+def test_users_with_temporary_password_are_redirected_until_password_changes(
+    client, admin_factory, login, route
+):
+    admin_factory(
+        email="temp-lock@shynebeauty.com",
+        full_name="Temp Lock",
+        role=ROLE_SUPERADMIN,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+    login(
+        client,
+        email="temp-lock@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    response = client.get(route)
+
+    assert response.status_code == 302
+    assert "/change-password" in response.headers["Location"]
+
+
+def test_forced_password_change_clears_requirement_and_restores_access(
+    client, admin_factory, app, login
+):
+    user = admin_factory(
+        email="temp-clear@shynebeauty.com",
+        full_name="Temp Clear",
+        role=ROLE_STAFF_OPERATOR,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+
+    login(
+        client,
+        email="temp-clear@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    response = client.post(
+        "/change-password?next=/orders",
+        data={
+            "password": "BrandNewPassw0rd!",
+            "password_confirmation": "BrandNewPassw0rd!",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/orders")
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, user.id)
+        assert refreshed_user.requires_password_change() is False
+        assert refreshed_user.check_password("BrandNewPassw0rd!") is True
+
+
 def test_superadmin_is_denied_admin_console_access(client, admin_user, login):
     login(client)
 
@@ -474,6 +557,7 @@ def test_runtime_auth_schema_compatibility_upgrades_legacy_admin_table_before_us
             } >= {
                 "role",
                 "account_status",
+                "must_change_password",
                 "permission_overrides_json",
             }
             user = db.session.get(AdminUser, 1)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -160,6 +160,13 @@ def test_internal_next_targets_with_query_params_are_allowed(client, admin_user,
     assert response.headers["Location"].endswith("/orders?status=open")
 
 
+def test_backslash_next_targets_are_normalized_when_safe(client, admin_user, login):
+    response = login(client, next_url="\\orders?status=open")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/orders?status=open")
+
+
 def test_authenticated_users_are_redirected_away_from_login(
     client, admin_user, login
 ):
@@ -431,6 +438,76 @@ def test_forced_password_change_clears_requirement_and_restores_access(
         refreshed_user = db.session.get(AdminUser, user.id)
         assert refreshed_user.requires_password_change() is False
         assert refreshed_user.check_password("BrandNewPassw0rd!") is True
+
+
+@pytest.mark.parametrize(
+    "next_url",
+    [
+        "//evil.example/phish",
+        "https://evil.example/phish",
+        "\\\\evil.example/phish",
+    ],
+)
+def test_forced_password_change_rejects_unsafe_next_targets(
+    client, admin_factory, login, next_url
+):
+    admin_factory(
+        email="temp-unsafe@shynebeauty.com",
+        full_name="Temp Unsafe",
+        role=ROLE_STAFF_OPERATOR,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+
+    login(
+        client,
+        email="temp-unsafe@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    response = client.post(
+        f"/change-password?next={next_url}",
+        data={
+            "next": next_url,
+            "password": "BrandNewPassw0rd!",
+            "password_confirmation": "BrandNewPassw0rd!",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/")
+
+
+def test_forced_password_change_normalizes_safe_backslash_next_targets(
+    client, admin_factory, login
+):
+    admin_factory(
+        email="temp-safe@shynebeauty.com",
+        full_name="Temp Safe",
+        role=ROLE_STAFF_OPERATOR,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+
+    login(
+        client,
+        email="temp-safe@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    response = client.post(
+        "/change-password?next=\\orders?status=open",
+        data={
+            "next": "\\orders?status=open",
+            "password": "BrandNewPassw0rd!",
+            "password_confirmation": "BrandNewPassw0rd!",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/orders?status=open")
 
 
 def test_superadmin_is_denied_admin_console_access(client, admin_user, login):

--- a/tests/test_users_access.py
+++ b/tests/test_users_access.py
@@ -19,7 +19,7 @@ def test_superadmin_can_view_users_page(client, admin_user, login):
 
     assert response.status_code == 200
     assert b"Users & Access" in response.data
-    assert b"Invite user" in response.data
+    assert b"Create user" in response.data
 
 
 def test_dev_admin_is_hidden_from_users_table(client, admin_user, dev_admin_user, login):
@@ -31,25 +31,66 @@ def test_dev_admin_is_hidden_from_users_table(client, admin_user, dev_admin_user
     assert b"devadmin@shynebeauty.com" not in response.data
 
 
-def test_superadmin_can_invite_business_user(client, admin_user, app, login):
+def test_create_user_with_manual_temporary_password(
+    client, admin_user, app, login
+):
+    login(client)
+
+    invite_response = client.post(
+        "/users/invite",
+        data={
+            "full_name": "Taylor Temp",
+            "email": "taylor@shynebeauty.com",
+            "role": ROLE_STAFF_OPERATOR,
+            "password_mode": "manual",
+            "password": "TempPassw0rd!",
+            "password_confirmation": "TempPassw0rd!",
+        },
+    )
+
+    assert invite_response.status_code == 302
+
+    with app.app_context():
+        created_user = AdminUser.query.filter_by(email="taylor@shynebeauty.com").one()
+        assert created_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+        assert created_user.get_role() == ROLE_STAFF_OPERATOR
+        assert created_user.check_password("TempPassw0rd!") is True
+        assert created_user.requires_password_change() is True
+
+    client.post("/logout")
+    login_response = login(
+        client,
+        email="taylor@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    assert login_response.status_code == 302
+    assert "/change-password" in login_response.headers["Location"]
+
+
+def test_create_user_with_generated_temporary_password_shows_password_once(
+    client, admin_user, app, login
+):
     login(client)
 
     response = client.post(
         "/users/invite",
         data={
-            "full_name": "New Operator",
-            "email": "new-operator@shynebeauty.com",
+            "full_name": "Jordan Generated",
+            "email": "jordan@shynebeauty.com",
             "role": ROLE_STAFF_OPERATOR,
+            "password_mode": "generated",
         },
+        follow_redirects=True,
     )
 
-    assert response.status_code == 302
+    assert response.status_code == 200
+    assert b"Temporary password (shown once):" in response.data
 
     with app.app_context():
-        invited = AdminUser.query.filter_by(email="new-operator@shynebeauty.com").one()
-        assert invited.get_role() == ROLE_STAFF_OPERATOR
-        assert invited.get_account_status() == ACCOUNT_STATUS_INVITED
-        assert invited.invited_at is not None
+        created_user = AdminUser.query.filter_by(email="jordan@shynebeauty.com").one()
+        assert created_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+        assert created_user.requires_password_change() is True
 
 
 def test_last_active_superadmin_cannot_be_demoted(client, admin_user, app, login):
@@ -111,7 +152,7 @@ def test_superadmin_can_demote_another_superadmin_when_not_last(
         assert user.get_role() == ROLE_STAFF_OPERATOR
 
 
-def test_superadmin_can_reset_password_for_active_business_user(
+def test_superadmin_can_set_temporary_password_for_active_business_user(
     client, admin_user, staff_user, app, login
 ):
     login(client)
@@ -119,8 +160,8 @@ def test_superadmin_can_reset_password_for_active_business_user(
     response = client.post(
         f"/users/{staff_user}/temporary-password",
         data={
-            "password": "NewPassw0rd!",
-            "password_confirmation": "NewPassw0rd!",
+            "password": "NewTempPassw0rd!",
+            "password_confirmation": "NewTempPassw0rd!",
         },
     )
 
@@ -128,10 +169,13 @@ def test_superadmin_can_reset_password_for_active_business_user(
 
     with app.app_context():
         user = db.session.get(AdminUser, staff_user)
-        assert user.check_password("NewPassw0rd!") is True
+        assert user.check_password("NewTempPassw0rd!") is True
+        assert user.requires_password_change() is True
 
 
-def test_pending_invite_can_be_activated(client, admin_user, admin_factory, app, login):
+def test_legacy_pending_invite_can_still_be_activated_with_temporary_password(
+    client, admin_user, admin_factory, app, login
+):
     with app.app_context():
         invited_user = admin_factory(
             email="legacy-invite@shynebeauty.com",
@@ -147,8 +191,8 @@ def test_pending_invite_can_be_activated(client, admin_user, admin_factory, app,
     response = client.post(
         f"/users/{invited_user_id}/activate",
         data={
-            "password": "WelcomePassw0rd!",
-            "password_confirmation": "WelcomePassw0rd!",
+            "password": "LegacyTempPassw0rd!",
+            "password_confirmation": "LegacyTempPassw0rd!",
         },
     )
 
@@ -157,7 +201,8 @@ def test_pending_invite_can_be_activated(client, admin_user, admin_factory, app,
     with app.app_context():
         activated_user = db.session.get(AdminUser, invited_user_id)
         assert activated_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
-        assert activated_user.check_password("WelcomePassw0rd!") is True
+        assert activated_user.requires_password_change() is True
+        assert activated_user.check_password("LegacyTempPassw0rd!") is True
 
 
 def test_users_page_can_filter_pending_invites(


### PR DESCRIPTION
## Summary
- replace invite-first account creation with temporary password account creation
- force users created with a temporary password through `/change-password` on first login
- block normal app access until the password is changed
- keep legacy invited-account activation support for compatibility

## changed 
- add `must_change_password` state to admin auth records
- add generated and manual temporary password creation paths in `/users`
- add the `/change-password` flow and first-login redirect enforcement
- update temporary password reset behavior so active users must change the reset password at next login
- keep existing `invited` account activation working for older rows

## stacked PR
- this PR is based on the previously merged admin access foundation and `/users` UI work
