### PR TITLE
Add CSRF protection for auth and user actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-SQLAlchemy>=3.1,<4.0
 Flask-Login>=0.6,<1.0
 python-dotenv>=1.0,<2.0
 Flask-Admin>=1.6,<3.0
+Flask-WTF>=1.2,<2.0
 pytest>=8.0,<10.0
 WTForms>=3.1,<3.3
 SQLAlchemy>=2.0,<3.0

--- a/shyne.py
+++ b/shyne.py
@@ -33,6 +33,7 @@ from flask_login import (
     logout_user,
 )
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFError, CSRFProtect
 from sqlalchemy.orm import validates
 from sqlalchemy import inspect, or_, text
 from sqlalchemy.exc import OperationalError
@@ -283,8 +284,10 @@ app.config["SESSION_COOKIE_SECURE"] = env_flag("SESSION_COOKIE_SECURE", default=
 app.config["REMEMBER_COOKIE_HTTPONLY"] = True
 app.config["REMEMBER_COOKIE_SAMESITE"] = "Lax"
 app.config["REMEMBER_COOKIE_SECURE"] = app.config["SESSION_COOKIE_SECURE"]
+app.config["WTF_CSRF_ENABLED"] = True
 
 db = SQLAlchemy(app)
+csrf = CSRFProtect(app)
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
 login_manager.login_message = "Please sign in to continue."
@@ -341,6 +344,28 @@ def redirect_to_safe_next(target, *, fallback_endpoint="index"):
     if safe_target:
         return redirect(safe_target)
     return redirect(url_for(fallback_endpoint))
+
+
+@app.errorhandler(CSRFError)
+def handle_csrf_error(error):
+    flash(error.description or "Invalid CSRF token.", "error")
+
+    if request.endpoint == "login":
+        return render_template(
+            "login.html",
+            form_data={"email": "", "remember_me": False},
+            next_url=get_safe_next_target(request.args.get("next")),
+            show_dev_test_admin_hint=dev_test_admin_enabled(),
+            dev_test_admin_seeded=dev_test_admin_seeded(),
+        ), 400
+
+    if request.endpoint == "change_password":
+        return render_template(
+            "change_password.html",
+            next_url=get_safe_next_target(request.args.get("next")),
+        ), 400
+
+    return redirect(request.referrer or url_for("index"))
 
 
 def current_request_next_target():

--- a/templates/_form_helpers.html
+++ b/templates/_form_helpers.html
@@ -1,0 +1,3 @@
+{% macro csrf_input() -%}
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+{%- endmacro %}

--- a/templates/base_authenticated.html
+++ b/templates/base_authenticated.html
@@ -11,6 +11,7 @@
   {% block head_extra %}{% endblock %}
 </head>
 <body>
+  {% from "_form_helpers.html" import csrf_input %}
   <a class="sb-skip-link" href="#main-content">Skip to main content</a>
   <div class="sb-mobile-overlay" id="sb-mobile-overlay" hidden></div>
   <div class="sb-shell">
@@ -36,6 +37,7 @@
           <span>{{ current_admin_role_label }}</span>
         </div>
         <form method="post" action="{{ url_for('logout') }}">
+          {{ csrf_input() }}
           <button class="sb-button-secondary" type="submit">Log out</button>
         </form>
       </div>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,4 +1,5 @@
 {% extends "base_authenticated.html" %}
+{% from "_form_helpers.html" import csrf_input %}
 
 {% block title %}Change Password{% endblock %}
 {% block page_title %}Change Password{% endblock %}
@@ -11,6 +12,7 @@
     <h2>Set a new password</h2>
     <p class="sb-section-note">This account is using a temporary password. Update it now to continue.</p>
     <form class="sb-form-grid" method="post" action="{{ url_for('change_password') }}">
+      {{ csrf_input() }}
       {% if next_url %}
         <input type="hidden" name="next" value="{{ next_url }}">
       {% endif %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,6 +11,7 @@
 </head>
 
 <body class="sb-login-body">
+  {% from "_form_helpers.html" import csrf_input %}
   <main class="sb-login-shell">
     <section class="sb-login-panel" aria-labelledby="login-heading">
       <div class="sb-brand-mark">
@@ -55,6 +56,7 @@
       {% endif %}
 
       <form method="post" action="{{ url_for('login') }}" novalidate>
+        {{ csrf_input() }}
         <input type="hidden" name="next" value="{{ next_url }}">
 
         <div class="sb-field sb-field-float">

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,4 +1,5 @@
 {% extends "base_authenticated.html" %}
+{% from "_form_helpers.html" import csrf_input %}
 
 {% macro hidden_filters(filter_state) -%}
   <input type="hidden" name="search" value="{{ filter_state.search }}">
@@ -255,6 +256,7 @@
         <h2 id="selected-user-heading">Create user</h2>
         <p class="sb-section-note">Create an active account with a temporary password. The user will be forced to change it on first login.</p>
         <form class="sb-form-grid" method="post" action="{{ url_for('invite_user') }}">
+          {{ csrf_input() }}
           {{ hidden_filters(filter_state) }}
           <div class="sb-field">
             <label for="invite-full-name">Full Name</label>
@@ -388,6 +390,7 @@
         <section class="sb-inspector-section">
           <h3>Change Role</h3>
           <form class="sb-form-grid" method="post" action="{{ url_for('update_user_role', user_id=selected_user.id) }}">
+            {{ csrf_input() }}
             {{ hidden_filters(filter_state) }}
             <div class="sb-field">
               <label for="role-{{ selected_user.id }}">Role</label>
@@ -411,6 +414,7 @@
             <h3>Activate Account</h3>
             <p class="sb-inline-note">Legacy invited account support only. Activation sets a temporary password and requires the user to change it on first login.</p>
             <form class="sb-form-grid" method="post" action="{{ url_for('activate_user', user_id=selected_user.id) }}">
+              {{ csrf_input() }}
               {{ hidden_filters(filter_state) }}
               <div class="sb-field">
                 <label for="activate-password-{{ selected_user.id }}">Temporary Password</label>
@@ -431,6 +435,7 @@
           <section class="sb-inspector-section">
             <h3>Set Temporary Password</h3>
             <form class="sb-form-grid" method="post" action="{{ url_for('set_temporary_password', user_id=selected_user.id) }}">
+              {{ csrf_input() }}
               {{ hidden_filters(filter_state) }}
               <div class="sb-field">
                 <label for="temporary-password-{{ selected_user.id }}">Temporary Password</label>
@@ -452,21 +457,25 @@
           {% if selected_user.get_account_status() == 'invited' %}
             <div class="sb-form-actions">
               <form method="post" action="{{ url_for('resend_invite', user_id=selected_user.id) }}">
+                {{ csrf_input() }}
                 {{ hidden_filters(filter_state) }}
                 <button class="sb-button-secondary" type="submit">Resend invite</button>
               </form>
               <form method="post" action="{{ url_for('cancel_invite', user_id=selected_user.id) }}">
+                {{ csrf_input() }}
                 {{ hidden_filters(filter_state) }}
                 <button class="sb-button-danger" type="submit">Cancel invite</button>
               </form>
             </div>
           {% elif selected_user.get_account_status() == 'active' %}
             <form method="post" action="{{ url_for('suspend_user', user_id=selected_user.id) }}">
+              {{ csrf_input() }}
               {{ hidden_filters(filter_state) }}
               <button class="sb-button-danger" type="submit">Suspend account</button>
             </form>
           {% else %}
             <form method="post" action="{{ url_for('reactivate_user', user_id=selected_user.id) }}">
+              {{ csrf_input() }}
               {{ hidden_filters(filter_state) }}
               <button class="sb-button" type="submit">Reactivate account</button>
             </form>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -44,6 +45,7 @@ def app():
         SECRET_KEY="test-secret-key",
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         ENABLE_DEV_TEST_ADMIN=False,
+        WTF_CSRF_ENABLED=False,
     )
 
     with flask_app.app_context():
@@ -60,6 +62,33 @@ def client(app):
 
 
 @pytest.fixture()
+def csrf_client(app):
+    original_value = app.config["WTF_CSRF_ENABLED"]
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        yield app.test_client()
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = original_value
+
+
+def extract_csrf_token(response_data):
+    html = response_data.decode("utf-8")
+    match = re.search(r'name="csrf_token"\s+value="([^"]+)"', html)
+    assert match, "Expected a CSRF token in the response body."
+    return match.group(1)
+
+
+@pytest.fixture()
+def csrf_token_for():
+    def _csrf_token_for(client, path):
+        response = client.get(path)
+        assert response.status_code == 200
+        return extract_csrf_token(response.data)
+
+    return _csrf_token_for
+
+
+@pytest.fixture()
 def login():
     def _login(
         client,
@@ -73,6 +102,8 @@ def login():
             "email": email,
             "password": password,
         }
+        if client.application.config.get("WTF_CSRF_ENABLED"):
+            data["csrf_token"] = extract_csrf_token(client.get("/login").data)
         if remember_me:
             data["remember_me"] = "on"
         if next_url is not None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -26,6 +26,19 @@ def test_login_route_sets_security_headers(client):
     assert response.headers["X-Frame-Options"] == "SAMEORIGIN"
 
 
+def test_login_rejects_missing_csrf_token(csrf_client, admin_user):
+    response = csrf_client.post(
+        "/login",
+        data={
+            "email": "admin@shynebeauty.com",
+            "password": "correct-horse-battery-staple",
+        },
+    )
+
+    assert response.status_code == 400
+    assert b"CSRF" in response.data
+
+
 def test_login_route_rejects_missing_credentials_with_feedback(client):
     response = client.post("/login", data={"email": "", "password": ""})
 
@@ -205,6 +218,17 @@ def test_logout_clears_authentication(client, admin_user, login):
         if header.startswith("remember_token=")
     )
     assert "Expires=Thu, 01 Jan 1970" in remember_cookie
+
+
+def test_logout_rejects_missing_csrf_token(csrf_client, admin_user, login):
+    login(csrf_client)
+
+    response = csrf_client.post("/logout", follow_redirects=False)
+
+    assert response.status_code == 302
+
+    protected_response = csrf_client.get("/")
+    assert protected_response.status_code == 200
 
 
 def test_lockout_triggers_after_repeated_failed_attempts(client, admin_user, app, login):
@@ -438,6 +462,40 @@ def test_forced_password_change_clears_requirement_and_restores_access(
         refreshed_user = db.session.get(AdminUser, user.id)
         assert refreshed_user.requires_password_change() is False
         assert refreshed_user.check_password("BrandNewPassw0rd!") is True
+
+
+def test_forced_password_change_rejects_missing_csrf_token(
+    csrf_client, admin_factory, app, login
+):
+    user = admin_factory(
+        email="temp-csrf@shynebeauty.com",
+        full_name="Temp Csrf",
+        role=ROLE_STAFF_OPERATOR,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+
+    login(
+        csrf_client,
+        email="temp-csrf@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    response = csrf_client.post(
+        "/change-password?next=/orders",
+        data={
+            "password": "BrandNewPassw0rd!",
+            "password_confirmation": "BrandNewPassw0rd!",
+        },
+    )
+
+    assert response.status_code == 400
+    assert b"CSRF" in response.data
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, user.id)
+        assert refreshed_user.requires_password_change() is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_users_access.py
+++ b/tests/test_users_access.py
@@ -93,6 +93,31 @@ def test_create_user_with_generated_temporary_password_shows_password_once(
         assert created_user.requires_password_change() is True
 
 
+def test_users_invite_rejects_missing_csrf_token(
+    csrf_client, admin_user, app, login
+):
+    login(csrf_client)
+
+    response = csrf_client.post(
+        "/users/invite",
+        data={
+            "full_name": "Taylor Temp",
+            "email": "taylor@shynebeauty.com",
+            "role": ROLE_STAFF_OPERATOR,
+            "password_mode": "manual",
+            "password": "TempPassw0rd!",
+            "password_confirmation": "TempPassw0rd!",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    with app.app_context():
+        created_user = AdminUser.query.filter_by(email="taylor@shynebeauty.com").first()
+        assert created_user is None
+
+
 def test_last_active_superadmin_cannot_be_demoted(client, admin_user, app, login):
     login(client)
 


### PR DESCRIPTION
- add Flask-WTF CSRF protection to shipped POST routes
- render CSRF tokens on auth and `/users` mutation forms
- add CSRF-aware test helpers and coverage for representative protected POST routes