### PR TITLE
Fix PR71 regressions in auth state, orders, and mobile nav

### DIFF
--- a/shyne.py
+++ b/shyne.py
@@ -37,8 +37,9 @@ from flask_login import (
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from sqlalchemy.orm import validates
+from sqlalchemy.orm.exc import ObjectDeletedError
 from sqlalchemy import func, inspect, or_, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import InvalidRequestError, OperationalError
 from werkzeug.security import check_password_hash, generate_password_hash
 
 FAILED_LOGIN_THRESHOLD = 5
@@ -355,6 +356,32 @@ def parse_non_negative_decimal(raw_value, *, field_label):
     return value
 
 
+def read_line_items_form_data(form):
+    product_ids = form.getlist("product_id")
+    quantities = form.getlist("quantity")
+    unit_prices = form.getlist("unit_price")
+    lengths_match = len({len(product_ids), len(quantities), len(unit_prices)}) == 1
+    max_length = max(len(product_ids), len(quantities), len(unit_prices), 1)
+
+    line_items = []
+    for index in range(max_length):
+        line_items.append(
+            {
+                "product_id": (
+                    product_ids[index].strip() if index < len(product_ids) else ""
+                ),
+                "quantity": (
+                    quantities[index].strip() if index < len(quantities) else ""
+                ),
+                "unit_price": (
+                    unit_prices[index].strip() if index < len(unit_prices) else ""
+                ),
+            }
+        )
+
+    return line_items, lengths_match
+
+
 def is_safe_next_target(target):
     if not target:
         return False
@@ -442,6 +469,22 @@ def current_request_next_target():
     if request.query_string:
         return f"{request.path}?{request.query_string.decode('utf-8')}"
     return request.path
+
+
+def revoke_authenticated_session(*, redirect_to_login=True):
+    session.clear()
+    logout_user()
+    flash(
+        "Your session is no longer active. Sign in again or contact a superadmin.",
+        "error",
+    )
+    if not redirect_to_login:
+        return None
+
+    safe_next = get_safe_next_target(current_request_next_target())
+    if safe_next:
+        return redirect(url_for("login", next=safe_next))
+    return redirect(url_for("login"))
 
 
 def generate_temporary_password(length=16):
@@ -1741,7 +1784,7 @@ register_admin_views()
 @login_manager.user_loader
 def load_user(user_id):
     try:
-        return db.session.get(AdminUser, int(user_id))
+        return db.session.get(AdminUser, int(user_id), populate_existing=True)
     except (TypeError, ValueError):
         return None
 
@@ -1757,6 +1800,26 @@ def ensure_request_auth_schema_compatibility():
         return None
     ensure_runtime_auth_schema_compatibility()
     return None
+
+
+@app.before_request
+def invalidate_revoked_authenticated_session():
+    if request.endpoint == "static" or not current_user.is_authenticated:
+        return None
+
+    try:
+        db.session.refresh(current_user._get_current_object())
+    except (InvalidRequestError, ObjectDeletedError):
+        return revoke_authenticated_session(redirect_to_login=request.endpoint != "login")
+
+    comparison_time = utc_now()
+    if (
+        current_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+        and not current_user.is_locked(comparison_time)
+    ):
+        return None
+
+    return revoke_authenticated_session(redirect_to_login=request.endpoint != "login")
 
 
 @app.before_request
@@ -2243,29 +2306,16 @@ def add_order():
             "status": (request.form.get("status") or "").strip(),
             "placed_at": (request.form.get("placed_at") or "").strip(),
         }
-        
-        # Get line items from form
-        line_items_raw = list(
-            zip(
-                request.form.getlist("product_id"),
-                request.form.getlist("quantity"),
-                request.form.getlist("unit_price"),
-            )
-        )
-        line_items = [
-            {
-                "product_id": (product_id or "").strip(),
-                "quantity": (quantity or "").strip(),
-                "unit_price": (unit_price or "").strip(),
-            }
-            for product_id, quantity, unit_price in line_items_raw
-        ] or line_items
+        line_items, line_item_lengths_match = read_line_items_form_data(request.form)
 
         errors = []
         customer = None
         placed_at = None
         parsed_line_items = []
         total_amount = Decimal("0.00")
+
+        if not line_item_lengths_match:
+            errors.append("Each line item must include a product, quantity, and price.")
 
         if not form_data["order_number"]:
             errors.append("Order number is required.")

--- a/static/css/shyne.css
+++ b/static/css/shyne.css
@@ -1204,13 +1204,18 @@ code {
     bottom: 0;
     width: min(300px, calc(100vw - 32px));
     transform: translateX(-105%);
-    transition: transform 0.15s ease;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.15s ease, visibility 0s linear 0.15s;
     z-index: 30;
     box-shadow: 14px 0 32px rgba(90, 76, 60, 0.18);
   }
 
   .sb-sidebar[data-open="true"] {
     transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+    transition-delay: 0s;
   }
 
   .sb-mobile-overlay[data-open="true"] {

--- a/templates/base_authenticated.html
+++ b/templates/base_authenticated.html
@@ -13,7 +13,7 @@
 <body>
   {% from "_form_helpers.html" import csrf_input %}
   <a class="sb-skip-link" href="#main-content">Skip to main content</a>
-  <div class="sb-mobile-overlay" id="sb-mobile-overlay" hidden></div>
+  <div class="sb-mobile-overlay" id="sb-mobile-overlay" data-open="false" hidden></div>
   <div class="sb-shell">
     <header class="sb-header">
       <div class="sb-header-main">
@@ -43,7 +43,7 @@
       </div>
     </header>
 
-    <nav class="sb-sidebar" id="sb-sidebar" aria-label="Primary">
+    <nav class="sb-sidebar" id="sb-sidebar" aria-label="Primary" data-open="false">
       <a class="sb-sidebar-brand" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='shyneIcon.png') }}" alt="" width="40" height="40">
         <span class="sb-sidebar-brand-copy">
@@ -99,21 +99,34 @@
     const menuButton = document.getElementById("sb-menu-button");
 
     if (sidebar && overlay && menuButton) {
-      const toggleSidebar = (open) => {
-        sidebar.dataset.open = open ? "true" : "false";
-        overlay.dataset.open = open ? "true" : "false";
-        overlay.hidden = !open;
-        menuButton.setAttribute("aria-expanded", open ? "true" : "false");
+      const syncSidebarState = (requestedOpen) => {
+        const isMobile = window.innerWidth <= 980;
+        const isOpen = isMobile ? requestedOpen : true;
+        const overlayOpen = isMobile && isOpen;
+
+        sidebar.dataset.open = isOpen ? "true" : "false";
+        overlay.dataset.open = overlayOpen ? "true" : "false";
+        overlay.hidden = !overlayOpen;
+        menuButton.setAttribute("aria-expanded", overlayOpen ? "true" : "false");
+
+        if (isMobile && !isOpen) {
+          sidebar.setAttribute("aria-hidden", "true");
+          sidebar.setAttribute("inert", "");
+        } else {
+          sidebar.removeAttribute("aria-hidden");
+          sidebar.removeAttribute("inert");
+        }
       };
 
+      const sidebarIsOpen = () => menuButton.getAttribute("aria-expanded") === "true";
+
+      syncSidebarState(false);
       menuButton.addEventListener("click", () => {
-        toggleSidebar(menuButton.getAttribute("aria-expanded") !== "true");
+        syncSidebarState(!sidebarIsOpen());
       });
-      overlay.addEventListener("click", () => toggleSidebar(false));
+      overlay.addEventListener("click", () => syncSidebarState(false));
       window.addEventListener("resize", () => {
-        if (window.innerWidth > 980) {
-          toggleSidebar(false);
-        }
+        syncSidebarState(sidebarIsOpen());
       });
     }
   </script>

--- a/templates/users.html
+++ b/templates/users.html
@@ -22,7 +22,7 @@
       white-space: normal;
     }
 
-    .sb-users-table tbody tr[data-selected="true"] {
+    .sb-users-table tbody tr[aria-selected="true"] {
       background: #fbf4ea;
     }
 
@@ -202,7 +202,7 @@
           </thead>
           <tbody>
             {% for user in users_list %}
-              <tr {% if selected_user and selected_user.id == user.id %}data-selected="true"{% endif %}>
+              <tr {% if selected_user and selected_user.id == user.id %}aria-selected="true"{% endif %}>
                 <td data-label="Name">{{ user.full_name or "No name set" }}</td>
                 <td data-label="Email">{{ user.email }}</td>
                 <td data-label="Role">{{ user.get_role() }}</td>

--- a/tests/test_order_workflow.py
+++ b/tests/test_order_workflow.py
@@ -215,3 +215,47 @@ def test_add_order_validates_line_item_values(client, admin_user, app, login):
     assert response.status_code == 200
     assert b"Line item 1 quantity must be a positive whole number." in response.data
     assert b"Line item 1 price must be a valid non-negative amount." in response.data
+
+
+def test_add_order_rejects_misaligned_line_item_payloads(client, admin_user, app, login):
+    with app.app_context():
+        customer = Customer(
+            first_name="Taylor",
+            last_name="Customer",
+            email="taylor@shynebeauty.com",
+            country="USA",
+        )
+        product = Product(
+            name="Glow Balm",
+            sku="GB-001",
+            price=Decimal("24.50"),
+            active=True,
+            reorder_threshold=5,
+        )
+        db.session.add_all([customer, product])
+        db.session.commit()
+        customer_id = customer.id
+        product_id = product.id
+
+    login(client)
+
+    response = client.post(
+        "/add-order",
+        data={
+            "order_number": "ORD-1002",
+            "customer_id": str(customer_id),
+            "platform": "Direct",
+            "status": "Placed",
+            "placed_at": "2026-04-13",
+            "product_id": [str(product_id), str(product_id)],
+            "quantity": ["1"],
+            "unit_price": ["24.50", "24.50"],
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Each line item must include a product, quantity, and price." in response.data
+
+    with app.app_context():
+        assert Order.query.filter_by(order_number="ORD-1002").count() == 0

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,7 +3,16 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import inspect, select, text
 
-from shyne import AUTH_BIND_KEY, ACCOUNT_STATUS_ACTIVE, AdminUser, ROLE_STAFF_OPERATOR, ROLE_SUPERADMIN, db
+from shyne import (
+    AUTH_BIND_KEY,
+    ACCOUNT_STATUS_ACTIVE,
+    ACCOUNT_STATUS_SUSPENDED,
+    AdminUser,
+    ROLE_STAFF_OPERATOR,
+    ROLE_SUPERADMIN,
+    db,
+    utc_now,
+)
 
 
 @pytest.mark.parametrize(
@@ -120,6 +129,19 @@ def test_unknown_credentials_are_rejected(client):
 
     assert response.status_code == 200
     assert b"Invalid email or password." in response.data
+
+
+def test_authenticated_shell_includes_skip_link_and_live_region(
+    client, admin_user, login
+):
+    login(client)
+
+    response = client.get("/orders")
+
+    assert response.status_code == 200
+    assert b'href="#main-content"' in response.data
+    assert b'<main class="sb-main" id="main-content">' in response.data
+    assert b'<nav class="sb-sidebar"' in response.data
 
 
 def test_inactive_admin_cannot_log_in(client, app, login):
@@ -554,6 +576,46 @@ def test_forced_password_change_clears_requirement_and_restores_access(
         refreshed_user = db.session.get(AdminUser, user.id)
         assert refreshed_user.requires_password_change() is False
         assert refreshed_user.check_password("BrandNewPassw0rd!") is True
+
+
+def test_suspended_user_with_temporary_password_is_logged_out_before_password_change(
+    client, admin_factory, app, login
+):
+    user = admin_factory(
+        email="temp-suspended@shynebeauty.com",
+        full_name="Temp Suspended",
+        role=ROLE_STAFF_OPERATOR,
+        account_status=ACCOUNT_STATUS_ACTIVE,
+        must_change_password=True,
+        password="TempPassw0rd!",
+    )
+
+    login(
+        client,
+        email="temp-suspended@shynebeauty.com",
+        password="TempPassw0rd!",
+    )
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, user.id)
+        refreshed_user.set_account_status(ACCOUNT_STATUS_SUSPENDED, now=utc_now())
+        db.session.commit()
+
+    response = client.post(
+        "/change-password?next=/orders",
+        data={
+            "password": "BrandNewPassw0rd!",
+            "password_confirmation": "BrandNewPassw0rd!",
+        },
+    )
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, user.id)
+        assert refreshed_user.requires_password_change() is True
+        assert refreshed_user.check_password("BrandNewPassw0rd!") is False
 
 
 def test_forced_password_change_rejects_missing_csrf_token(

--- a/tests/test_users_access.py
+++ b/tests/test_users_access.py
@@ -1,8 +1,11 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from shyne import (
     ACCOUNT_STATUS_ACTIVE,
     ACCOUNT_STATUS_INVITED,
+    ACCOUNT_STATUS_SUSPENDED,
     PERMISSION_ADMIN_CONSOLE_ACCESS,
     ROLE_DEV_ADMIN,
     ROLE_STAFF_OPERATOR,
@@ -29,6 +32,15 @@ def test_dev_admin_is_hidden_from_users_table(client, admin_user, dev_admin_user
 
     assert response.status_code == 200
     assert b"devadmin@shynebeauty.com" not in response.data
+
+
+def test_users_page_marks_selected_row_for_assistive_tech(client, admin_user, login):
+    login(client)
+
+    response = client.get("/users")
+
+    assert response.status_code == 200
+    assert b'aria-selected="true"' in response.data
 
 
 def test_create_user_with_manual_temporary_password(
@@ -228,6 +240,132 @@ def test_legacy_pending_invite_can_still_be_activated_with_temporary_password(
         assert activated_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
         assert activated_user.requires_password_change() is True
         assert activated_user.check_password("LegacyTempPassw0rd!") is True
+
+
+def test_superadmin_can_resend_pending_invite(client, admin_user, admin_factory, app, login):
+    with app.app_context():
+        invited_user = admin_factory(
+            email="pending-resend@shynebeauty.com",
+            full_name="Pending Resend",
+            password=None,
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_INVITED,
+        )
+        invited_user.invited_at = datetime.now(timezone.utc) - timedelta(days=3)
+        db.session.commit()
+        invited_user_id = invited_user.id
+        original_invited_at = invited_user.invited_at
+
+    login(client)
+
+    response = client.post(f"/users/{invited_user_id}/resend-invite")
+
+    assert response.status_code == 302
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, invited_user_id)
+        assert refreshed_user.get_account_status() == ACCOUNT_STATUS_INVITED
+        assert refreshed_user.invited_at > original_invited_at
+        assert refreshed_user.invited_by_user_id == admin_user
+
+
+def test_superadmin_can_cancel_pending_invite(client, admin_user, admin_factory, app, login):
+    with app.app_context():
+        invited_user = admin_factory(
+            email="pending-cancel@shynebeauty.com",
+            full_name="Pending Cancel",
+            password=None,
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_INVITED,
+        )
+        invited_user_id = invited_user.id
+
+    login(client)
+
+    response = client.post(f"/users/{invited_user_id}/cancel-invite")
+
+    assert response.status_code == 302
+
+    with app.app_context():
+        assert db.session.get(AdminUser, invited_user_id) is None
+
+
+def test_superadmin_can_reactivate_suspended_user(client, admin_user, admin_factory, app, login):
+    with app.app_context():
+        suspended_user = admin_factory(
+            email="reactivate@shynebeauty.com",
+            full_name="Reactivate User",
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_SUSPENDED,
+            failed_login_count=4,
+            locked_until=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        suspended_user_id = suspended_user.id
+
+    login(client)
+
+    response = client.post(f"/users/{suspended_user_id}/reactivate")
+
+    assert response.status_code == 302
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, suspended_user_id)
+        assert refreshed_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+        assert refreshed_user.failed_login_count == 0
+        assert refreshed_user.locked_until is None
+
+
+def test_activate_user_rejects_non_invited_account(client, admin_user, staff_user, app, login):
+    login(client)
+
+    response = client.post(
+        f"/users/{staff_user}/activate",
+        data={
+            "password": "LegacyTempPassw0rd!",
+            "password_confirmation": "LegacyTempPassw0rd!",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Only pending invites can be activated." in response.data
+
+    with app.app_context():
+        active_user = db.session.get(AdminUser, staff_user)
+        assert active_user.get_account_status() == ACCOUNT_STATUS_ACTIVE
+        assert active_user.check_password("LegacyTempPassw0rd!") is False
+
+
+def test_temporary_password_rejects_non_active_account(
+    client, admin_user, admin_factory, app, login
+):
+    with app.app_context():
+        suspended_user = admin_factory(
+            email="suspended-reset@shynebeauty.com",
+            full_name="Suspended Reset",
+            role=ROLE_STAFF_OPERATOR,
+            account_status=ACCOUNT_STATUS_SUSPENDED,
+        )
+        suspended_user_id = suspended_user.id
+
+    login(client)
+
+    response = client.post(
+        f"/users/{suspended_user_id}/temporary-password",
+        data={
+            "password": "NewTempPassw0rd!",
+            "password_confirmation": "NewTempPassw0rd!",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Only active accounts can receive a temporary password." in response.data
+
+    with app.app_context():
+        refreshed_user = db.session.get(AdminUser, suspended_user_id)
+        assert refreshed_user.get_account_status() == ACCOUNT_STATUS_SUSPENDED
+        assert refreshed_user.check_password("NewTempPassw0rd!") is False
 
 
 def test_users_page_can_filter_pending_invites(


### PR DESCRIPTION
- added `read_line_items_form_data()` and validation for uneven `product_id` / `quantity` / `unit_price` arrays
- updated the authenticated shell sidebar behavior to use `aria-hidden` and `inert` when closed on mobile
- updated `/users` selected-row semantics to use `aria-selected`