### PR TITLE
Fix dotenv loading for SECRET_KEY at app startup

### DIFF
--- a/shyne_app/app.py
+++ b/shyne_app/app.py
@@ -1,7 +1,8 @@
 from .config import *
 from .extensions import app, init_extensions
 
-load_project_env()
+# Config docs and local setup store dotenv files at project root
+load_project_env(BASE_DIR.parent)
 app.config["SECRET_KEY"] = require_env("SECRET_KEY")
 runtime_database_config = resolve_runtime_database_config(BASE_DIR.parent)
 app.config["APP_RUNTIME"] = runtime_database_config["runtime"]


### PR DESCRIPTION
- The app was looking for dotenv files under shyne_app/, but the repo uses .env/local.env at the repository root. 
- RuntimeError: SECRET_KEY environment variable must be set.