### PR TITLE
fix bare except in generate_order_number

### DIFF
--- a/shyne_app/routes.py
+++ b/shyne_app/routes.py
@@ -555,7 +555,7 @@ def generate_order_number():
         try:
             last_num = int(last_order.order_number.split('-')[-1])
             new_num = last_num + 1
-        except:
+        except (ValueError, AttributeError):
             new_num = 1
     else:
         new_num = 1


### PR DESCRIPTION
- Replaced a bare `except:` clause with `except (ValueError, AttributeError):`.
- The form catches KeyboardInterrupt and SystemExit, which doesn't log errors and prevents clean shutdowns.