### PR TITLE
fix: gate X-Forwarded-For on TRUST_PROXY_HEADERS

### DIFF
--- a/shyne_app/routes.py
+++ b/shyne_app/routes.py
@@ -53,11 +53,11 @@ from .auth import *
 
 
 def _request_client_ip():
-    return (
-        request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
-        or request.remote_addr
-        or "unknown"
-    )
+    if app.config.get("TRUST_PROXY_HEADERS"):
+        forwarded = request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+        if forwarded:
+            return forwarded
+    return request.remote_addr or "unknown"
 
 
 def _login_setup_error_response():


### PR DESCRIPTION
- `_request_client_ip()` was reading X-Forwarded-For unconditionally. An attacker  could spoof IP and bypass login throttling 
- Now the header is only trusted when TRUST_PROXY_HEADERS=true. 
- Without it, request.remote_addr is used instead.