### PR TITLE
redirect http to https and add HSTS in live-prod

### DIFF
--- a/shyne_app/app.py
+++ b/shyne_app/app.py
@@ -81,6 +81,14 @@ _logger.info(
     app.debug,
 )
 
+if app.config["APP_RUNTIME"] == APP_RUNTIME_LIVE_PROD and not app.config.get("SESSION_COOKIE_SECURE"):
+    import warnings
+    warnings.warn(
+        "SESSION_COOKIE_SECURE is False in live-prod — session cookies will be sent over HTTP. "
+        "Set SESSION_COOKIE_SECURE=true and deploy behind HTTPS.",
+        stacklevel=1,
+    )
+
 init_extensions(app)
 
 from . import models as _models  # noqa: E402,F401

--- a/shyne_app/auth.py
+++ b/shyne_app/auth.py
@@ -205,10 +205,28 @@ def enforce_password_change():
     return redirect(url_for("change_password"))
 
 
+@app.before_request
+def enforce_https():
+    if app.config.get("APP_RUNTIME") != APP_RUNTIME_LIVE_PROD:
+        return None
+    if not app.config.get("TRUST_PROXY_HEADERS"):
+        return None
+    proto = request.headers.get("X-Forwarded-Proto", "https")
+    if proto == "http":
+        return redirect(request.url.replace("http://", "https://", 1), code=301)
+    return None
+
+
 @app.after_request
 def add_security_headers(response):
     for header_name, header_value in SECURITY_HEADERS.items():
         response.headers.setdefault(header_name, header_value)
+
+    if app.config.get("APP_RUNTIME") == APP_RUNTIME_LIVE_PROD:
+        response.headers.setdefault(
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains",
+        )
 
     should_disable_caching = request.endpoint != "static" and (
         request.endpoint in NO_STORE_ENDPOINTS or current_user.is_authenticated


### PR DESCRIPTION
 changes  to APP_RUNTIME=live-prod:

1. Before-request hook redirects HTTP → HTTPS (301) when TRUST_PROXY_HEADERS
   is set and X-Forwarded-Proto is "http"
2. After-request hook sets Strict-Transport-Security with a 1-year max-age

A startup warning is given if SESSION_COOKIE_SECURE is False in live-prod.

No effect in demo-dev or test environments.