### PR TITLE
rate limit /change-password, /account/settings, and /admin routes

### DIFF
--- a/shyne_app/app.py
+++ b/shyne_app/app.py
@@ -97,5 +97,6 @@ from . import auth as _auth  # noqa: E402,F401
 from . import admin as _admin  # noqa: E402,F401
 from . import routes as _routes  # noqa: E402,F401
 from . import cli as _cli  # noqa: E402,F401
+from . import rate_limit as _rate_limit  # noqa: E402,F401
 
 _admin.register_admin_views()

--- a/shyne_app/auth.py
+++ b/shyne_app/auth.py
@@ -14,6 +14,7 @@ import click
 from dotenv import dotenv_values
 from flask import (
     Flask,
+    abort,
     flash,
     got_request_exception,
     redirect,
@@ -47,6 +48,38 @@ from .config import *
 from .extensions import app, db, login_manager
 from .models import *
 from .access import *
+from .rate_limit import check_rate_limit
+
+
+def _rate_limit_client_ip():
+    if app.config.get("TRUST_PROXY_HEADERS"):
+        forwarded = request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+        if forwarded:
+            return forwarded
+    return request.remote_addr or "unknown"
+
+
+@app.before_request
+def enforce_rate_limits():
+    if app.config.get("TESTING"):
+        return None
+    if request.endpoint == "static":
+        return None
+    if not check_rate_limit(_rate_limit_client_ip(), request.path, request.method):
+        abort(429)
+    return None
+
+
+@app.errorhandler(429)
+def handle_429(error):
+    flash("Too many requests. Please wait a moment and try again.", "error")
+    referrer = request.referrer
+    if referrer:
+        parsed = urlparse(referrer)
+        if parsed.netloc == request.host:
+            return redirect(referrer), 429
+    return redirect(url_for("login")), 429
+
 
 _logger = logging.getLogger("shynebeauty.errors")
 

--- a/shyne_app/rate_limit.py
+++ b/shyne_app/rate_limit.py
@@ -1,0 +1,52 @@
+import threading
+import time
+from collections import defaultdict
+
+_SENSITIVE_POST_PATHS = frozenset({
+    "/change-password",
+    "/account/settings",
+})
+
+_SENSITIVE_POST_LIMIT = 30   # requests per minute
+_ADMIN_LIMIT = 60            # requests per minute
+_WINDOW = 60.0               # seconds
+
+
+class _RateLimiter:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._buckets: dict = defaultdict(list)
+
+    def is_allowed(self, key: str, limit: int, window: float) -> bool:
+        now = time.monotonic()
+        cutoff = now - window
+        with self._lock:
+            timestamps = self._buckets[key]
+            while timestamps and timestamps[0] < cutoff:
+                timestamps.pop(0)
+            if len(timestamps) >= limit:
+                return False
+            timestamps.append(now)
+            return True
+
+    def cleanup(self, max_keys: int = 10_000) -> None:
+        with self._lock:
+            if len(self._buckets) <= max_keys:
+                return
+            now = time.monotonic()
+            stale = [k for k, v in self._buckets.items() if not v or v[-1] < now - 120]
+            for k in stale:
+                del self._buckets[k]
+
+
+_limiter = _RateLimiter()
+
+
+def check_rate_limit(ip: str, path: str, method: str) -> bool:
+    if method == "POST" and path in _SENSITIVE_POST_PATHS:
+        return _limiter.is_allowed(f"post:{ip}:{path}", _SENSITIVE_POST_LIMIT, _WINDOW)
+
+    if path.startswith("/admin"):
+        return _limiter.is_allowed(f"admin:{ip}", _ADMIN_LIMIT, _WINDOW)
+
+    return True


### PR DESCRIPTION
Adds a  rate limiter (stdlib)

- /change-password and /account/settings: 30 POST requests/min per IP
- /admin/*: 60 requests/min per IP
- All other routes: unlimited
- Disabled in TESTING mode so existing test suites are unaffected
- 429 responses redirect back to the referring page or /login with a flash message