### PR TITLE
warn elevated-role users without MFA in account settings

### DIFF
--- a/shyne_app/routes.py
+++ b/shyne_app/routes.py
@@ -1431,9 +1431,15 @@ def account_settings():
                 flash("Multi-factor authentication disabled.", "success")
                 return redirect(url_for("account_settings"))
 
+    elevated_roles = {ROLE_INVENTORY_PRODUCTION, ROLE_SUPERADMIN, ROLE_DEV_ADMIN}
+    show_mfa_warning = (
+        current_user.get_role() in elevated_roles
+        and not current_user.has_mfa_enabled()
+    )
     return render_template(
         "account_settings.html",
         mfa_enabled=current_user.has_mfa_enabled(),
+        show_mfa_warning=show_mfa_warning,
         **mfa_context,
     )
 

--- a/templates/account_settings.html
+++ b/templates/account_settings.html
@@ -48,6 +48,19 @@
     </form>
   </section>
 
+  {% if show_mfa_warning %}
+  <div
+    class="sb-note-box"
+    style="max-width: 720px; border-left-color: #c8a060;"
+    role="alert"
+    aria-live="polite"
+  >
+    <strong>MFA is strongly recommended for this account.</strong>
+    This account has elevated permissions. Enable multi-factor authentication
+    below to protect it against unauthorised access.
+  </div>
+  {% endif %}
+
   <section class="sb-panel" style="max-width: 720px;">
     <h2>Multi-Factor Authentication</h2>
     <p class="sb-section-note">


### PR DESCRIPTION
- Users with Superadmin, Inventory/Production, or Dev Admin roles who have not enabled MFA now see a warning banner in Account Settings.
- No enforcement 
- The warning is advisory only. Roles below that see nothing different.