### PR TITLE
Polish admin UI and add route smoke coverage

### DIFF
--- a/shyne_app/config.py
+++ b/shyne_app/config.py
@@ -214,9 +214,9 @@ IP_LOGIN_LOCK_DURATION = timedelta(minutes=15)
 HTML_CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "
     "img-src 'self' data:; "
-    "style-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; "
     "script-src 'self' 'unsafe-inline'; "
-    "font-src 'self'; "
+    "font-src 'self' https://cdnjs.cloudflare.com; "
     "object-src 'none'; "
     "base-uri 'self'; "
     "frame-ancestors 'self'"

--- a/static/css/shyne.css
+++ b/static/css/shyne.css
@@ -248,6 +248,32 @@ button {
   font-weight: 700;
 }
 
+.sb-button-small {
+  min-height: 32px;
+  padding: 5px 10px;
+  font-size: 13px;
+  gap: 4px;
+}
+
+.sb-button-tiny {
+  min-height: 26px;
+  padding: 3px 8px;
+  font-size: 12px;
+  gap: 4px;
+}
+
+.sb-button-warm {
+  background: rgba(232, 213, 189, 0.85);
+  border-color: rgba(200, 168, 130, 0.85);
+  color: var(--sb-text-strong);
+}
+
+.sb-button-warm:hover,
+.sb-button-warm:focus-visible {
+  background: #e0c8a6;
+  color: var(--sb-text-strong);
+}
+
 /* =============================================
    HEADER BRAND & ACCOUNT
    ============================================= */
@@ -432,7 +458,9 @@ button {
 }
 
 .sb-flash,
-.sb-message {
+.sb-message,
+.error-message,
+.success-message {
   padding: 12px 14px;
   border-radius: var(--sb-radius-sm);
   border: 1px solid transparent;
@@ -442,14 +470,16 @@ button {
 }
 
 .sb-flash-error,
-.sb-message-error {
+.sb-message-error,
+.error-message {
   background: #f5ded4;
   color: var(--sb-error-text);
   border-color: #d8aa97;
   border-left-color: #c97b6a;
 }
 
-.sb-flash-success {
+.sb-flash-success,
+.success-message {
   background: #e0efe4;
   color: #3f5c47;
   border-color: #bfd4c5;
@@ -845,6 +875,15 @@ button {
 .sb-textarea:hover:not(:focus) {
   border-bottom-color: var(--sb-border-strong);
   background: rgba(250, 246, 240, 0.70);
+}
+
+.sb-input:read-only,
+.sb-input[readonly],
+.sb-textarea:read-only,
+.sb-textarea[readonly] {
+  background: rgba(232, 224, 212, 0.55);
+  color: var(--sb-text-muted, #6b6a63);
+  cursor: not-allowed;
 }
 
 /* Textarea — floating label starts at top, not center */

--- a/templates/addCustomer.html
+++ b/templates/addCustomer.html
@@ -60,7 +60,7 @@
       
       <div class="sb-form-row">
         <div class="sb-field sb-field-float">
-          <input class="sb-input" id="customer-email" name="email" type="email" inputmode="email" autocomplete="email" spellcheck="false" placeholder=" " value="{{ form_data.email }}" required {% if is_edit %}readonly style="background-color: #f5f5f5;"{% endif %}>
+          <input class="sb-input" id="customer-email" name="email" type="email" inputmode="email" autocomplete="email" spellcheck="false" placeholder=" " value="{{ form_data.email }}" required {% if is_edit %}readonly{% endif %}>
           <label for="customer-email">Email</label>
         </div>
         <div class="sb-field sb-field-float">

--- a/templates/base_authenticated.html
+++ b/templates/base_authenticated.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='shyneIcon.png') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/shyne.css') }}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   {% block head_extra %}{% endblock %}
 </head>
 <body>

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -110,9 +110,9 @@
   <section class="sb-panel" style="margin-top:16px;">
     <form class="sb-form-grid" method="get" action="{{ url_for('inventory') }}">
       <div class="sb-form-row">
-        <div class="sb-field">
+        <div class="sb-field sb-field-float">
+          <input class="sb-input" id="inventory-search" type="text" name="search" placeholder=" " value="{{ search_query or '' }}">
           <label for="inventory-search">Search Inventory</label>
-          <input class="sb-input" id="inventory-search" type="text" name="search" placeholder="Search by item name" value="{{ search_query or '' }}">
         </div>
         <div class="sb-field">
           <label for="inventory-status">Stock Status</label>

--- a/tests/test_route_reachability.py
+++ b/tests/test_route_reachability.py
@@ -1,0 +1,90 @@
+"""Smoke test: every GET-only, non-parametric authenticated route returns 200.
+
+Guards against silently-orphaned templates and broken `url_for` references
+that the registration test (test_app.py::test_routes_are_registered) does
+not catch — a route may be registered but still 500 on render.
+"""
+
+import pytest
+
+
+AUTHENTICATED_GET_ROUTES = [
+    "/",
+    "/account/settings",
+    "/orders",
+    "/add-order",
+    "/customers",
+    "/add-customer",
+    "/inventory",
+    "/add-inventory",
+    "/add-new",
+    "/manage-products",
+    "/add-product",
+    "/product-batches",
+    "/add-product-batch",
+    "/users",
+]
+
+
+PUBLIC_GET_ROUTES = [
+    "/login",
+    "/health",
+]
+
+
+@pytest.mark.parametrize("path", PUBLIC_GET_ROUTES)
+def test_public_routes_return_200(client, path):
+    response = client.get(path)
+    assert response.status_code == 200, (
+        f"GET {path} returned {response.status_code}"
+    )
+
+
+@pytest.mark.parametrize("path", AUTHENTICATED_GET_ROUTES)
+def test_authenticated_routes_return_200(client, admin_user, login, path):
+    login(client)
+    response = client.get(path)
+    assert response.status_code == 200, (
+        f"GET {path} returned {response.status_code} for authenticated admin"
+    )
+
+
+def test_all_template_files_are_rendered_somewhere(app):
+    """Every .html template should be render_template()-ed by some route,
+    OR be a layout/partial (base_*, _form_helpers) or an error page.
+    """
+    import re
+    from pathlib import Path
+
+    templates_dir = Path(app.root_path).parent / "templates"
+    if not templates_dir.exists():
+        templates_dir = Path(app.root_path) / "templates"
+    all_templates = {p.name for p in templates_dir.glob("*.html")}
+
+    # Partials, layouts, and error pages don't need a direct route.
+    excluded = {
+        "base_authenticated.html",
+        "_form_helpers.html",
+        "error.html",
+        "access_denied.html",
+    }
+
+    source_files = [
+        Path(app.root_path) / "routes.py",
+        Path(app.root_path) / "auth.py",
+        Path(app.root_path) / "admin.py",
+        Path(app.root_path) / "access.py",
+        Path(app.root_path) / "config.py",
+    ]
+    rendered = set()
+    pattern = re.compile(r'render_template\(\s*["\']([A-Za-z0-9_./-]+\.html)["\']')
+    for src in source_files:
+        if src.exists():
+            rendered.update(pattern.findall(src.read_text(encoding="utf-8")))
+
+    unrendered = all_templates - rendered - excluded
+    assert not unrendered, (
+        f"Template files are never render_template()-ed: {sorted(unrendered)}. "
+        "Either wire them up to a route, add to the excluded partials set, "
+        "or delete them."
+    )


### PR DESCRIPTION
- add Font Awesome to the authenticated layout and update CSP to allow the CDN-hosted stylesheet/fonts
- polish shared button, flash/message, readonly-input, and inventory search field styling
- add coverage for public and authenticated GET routes and a guard that every top-level template is rendered somewhere
