### PR TITLE
Fix rotating file logger for local and test environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Optional variables:
 - `APP_RUNTIME=demo-dev|live-prod`
 - `DATABASE_URL`
 - `AUTH_DATABASE_URL`
+- `SHYNE_LOG_DIR` to override the default `instance/logs` directory
+- `DISABLE_FILE_LOGGING=true` to disable the rotating file logger
 - `FLASK_DEBUG=true` for debugging only
 - `SESSION_COOKIE_SECURE=true` for HTTPS
 - `TRUST_PROXY_HEADERS=true` only when the app is behind a trusted reverse proxy

--- a/shyne_app/app.py
+++ b/shyne_app/app.py
@@ -1,13 +1,50 @@
 import logging
 import logging.handlers
+import os
+import time
+from pathlib import Path
 
 from .config import *
 from .extensions import app, init_extensions
 
 
-def _configure_logging(runtime: str, log_dir) -> None:
-    log_dir = log_dir if hasattr(log_dir, "mkdir") else __import__("pathlib").Path(log_dir)
-    log_dir.mkdir(exist_ok=True)
+class SafeTimedRotatingFileHandler(logging.handlers.TimedRotatingFileHandler):
+    def doRollover(self):
+        try:
+            super().doRollover()
+        except PermissionError:
+            current_time = int(time.time())
+            next_rollover = self.computeRollover(current_time)
+            while next_rollover <= current_time:
+                next_rollover += self.interval
+            self.rolloverAt = next_rollover
+
+            if self.stream:
+                try:
+                    self.stream.close()
+                except OSError:
+                    pass
+                self.stream = None
+            self.stream = self._open()
+
+
+def _resolve_log_dir(project_root, environ=None) -> Path:
+    environ = environ or os.environ
+    configured_log_dir = (environ.get("SHYNE_LOG_DIR") or "").strip()
+    if configured_log_dir:
+        return Path(configured_log_dir)
+    return Path(project_root) / "instance" / "logs"
+
+
+def _configure_logging(
+    runtime: str,
+    log_dir,
+    *,
+    enable_file_logging: bool = True,
+    logger_name: str = "shynebeauty",
+) -> logging.Logger:
+    log_dir = log_dir if hasattr(log_dir, "mkdir") else Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     level = logging.DEBUG if runtime == APP_RUNTIME_DEMO_DEV else logging.INFO
     fmt = logging.Formatter(
@@ -15,24 +52,37 @@ def _configure_logging(runtime: str, log_dir) -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    file_handler = logging.handlers.TimedRotatingFileHandler(
-        log_dir / "shynebeauty.log",
-        when="midnight",
-        backupCount=30,
-        encoding="utf-8",
-    )
-    file_handler.setFormatter(fmt)
-    file_handler.setLevel(level)
+    logger = logging.getLogger(logger_name)
+    if getattr(logger, "_shyne_logging_configured", False):
+        return logger
+
+    logger.setLevel(level)
+    logger.propagate = False
+    logger._shyne_logging_configured = True
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(fmt)
     console_handler.setLevel(logging.WARNING)
-
-    logger = logging.getLogger("shynebeauty")
-    logger.setLevel(level)
-    logger.addHandler(file_handler)
     logger.addHandler(console_handler)
-    logger.propagate = False
+
+    if not enable_file_logging:
+        return logger
+
+    try:
+        file_handler = SafeTimedRotatingFileHandler(
+            log_dir / "shynebeauty.log",
+            when="midnight",
+            backupCount=30,
+            encoding="utf-8",
+            delay=True,
+        )
+        file_handler.setFormatter(fmt)
+        file_handler.setLevel(level)
+        logger.addHandler(file_handler)
+    except OSError as exc:
+        logger.warning("File logging disabled: %s", exc)
+
+    return logger
 
 
 # Config docs and local setup store dotenv files at project root
@@ -78,7 +128,11 @@ if app.config["APP_RUNTIME"] == APP_RUNTIME_LIVE_PROD and env_flag(
 ):
     raise RuntimeError("FLASK_DEBUG must not be enabled in live-prod.")
 
-_configure_logging(app.config["APP_RUNTIME"], BASE_DIR.parent / "logs")
+_configure_logging(
+    app.config["APP_RUNTIME"],
+    _resolve_log_dir(BASE_DIR.parent),
+    enable_file_logging=not env_flag("DISABLE_FILE_LOGGING", default=False),
+)
 
 _logger = logging.getLogger("shynebeauty.startup")
 _logger.info(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -178,6 +179,114 @@ def test_readme_documents_gunicorn_as_linux_production_default():
 
     assert "APP_RUNTIME=live-prod gunicorn --bind 127.0.0.1:8000 shyne:app" in readme
     assert "Live requires explicit `APP_RUNTIME=live-prod`" in readme
+
+
+def test_resolve_log_dir_defaults_to_instance_logs():
+    from shyne_app.app import _resolve_log_dir
+
+    log_dir = _resolve_log_dir(Path("/tmp/shynebeauty-project"), environ={})
+
+    assert log_dir == Path("/tmp/shynebeauty-project/instance/logs")
+
+
+def test_resolve_log_dir_honors_environment_override():
+    from shyne_app.app import _resolve_log_dir
+
+    log_dir = _resolve_log_dir(
+        Path("/tmp/shynebeauty-project"),
+        environ={"SHYNE_LOG_DIR": "/var/log/shynebeauty"},
+    )
+
+    assert log_dir == Path("/var/log/shynebeauty")
+
+
+def test_configure_logging_is_idempotent(tmp_path):
+    from shyne_app.app import _configure_logging
+
+    logger_name = "shynebeauty.test.idempotent"
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger._shyne_logging_configured = False
+
+    try:
+        _configure_logging(
+            APP_RUNTIME_DEMO_DEV,
+            tmp_path,
+            logger_name=logger_name,
+        )
+        _configure_logging(
+            APP_RUNTIME_DEMO_DEV,
+            tmp_path,
+            logger_name=logger_name,
+        )
+
+        assert len(logger.handlers) == 2
+        assert sum(
+            isinstance(handler, logging.StreamHandler)
+            and not isinstance(handler, logging.handlers.TimedRotatingFileHandler)
+            for handler in logger.handlers
+        ) == 1
+        assert sum(
+            isinstance(handler, logging.handlers.TimedRotatingFileHandler)
+            for handler in logger.handlers
+        ) == 1
+    finally:
+        for handler in list(logger.handlers):
+            handler.close()
+            logger.removeHandler(handler)
+        logger._shyne_logging_configured = False
+
+
+def test_safe_timed_rotating_file_handler_recovers_from_permission_error(
+    monkeypatch, tmp_path
+):
+    from shyne_app.app import SafeTimedRotatingFileHandler
+
+    original_rollover = logging.handlers.TimedRotatingFileHandler.doRollover
+
+    def _raise_permission_error(self):
+        raise PermissionError("rename denied")
+
+    monkeypatch.setattr(
+        logging.handlers.TimedRotatingFileHandler,
+        "doRollover",
+        _raise_permission_error,
+    )
+
+    handler = SafeTimedRotatingFileHandler(
+        tmp_path / "shynebeauty.log",
+        when="midnight",
+        backupCount=1,
+        encoding="utf-8",
+        delay=True,
+    )
+
+    try:
+        handler.rolloverAt = 0
+        handler.doRollover()
+        assert handler.rolloverAt > 0
+
+        record = logging.LogRecord(
+            name="shynebeauty.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="after rollover fallback",
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+
+        assert "after rollover fallback" in (
+            tmp_path / "shynebeauty.log"
+        ).read_text(encoding="utf-8")
+    finally:
+        handler.close()
+        monkeypatch.setattr(
+            logging.handlers.TimedRotatingFileHandler,
+            "doRollover",
+            original_rollover,
+        )
 
 
 def test_app_runtime_sensitive_defaults_are_applied():


### PR DESCRIPTION
- move the default log file location from repo-root `logs/` to `instance/logs/`
- add a `SafeTimedRotatingFileHandler` that recovers from rollover `PermissionError`s
- make logger setup idempotent so handlers are not attached more than once
- add `SHYNE_LOG_DIR` and `DISABLE_FILE_LOGGING` environment options
- document the new logging configuration in the README
- add tests for log-dir resolution, idempotent setup, and rollover recovery

Local pytest and app startup were hitting file rotation issues against the repo-mounted log path, which produced repeated logging errors and obscured real test output.

